### PR TITLE
fix: add Container mock to fix TechnicalTestForm rendering

### DIFF
--- a/frontend/src/components/technical-test/__test__/TechnicalTestForm.test.tsx
+++ b/frontend/src/components/technical-test/__test__/TechnicalTestForm.test.tsx
@@ -9,6 +9,10 @@ vi.mock("react-router", () => ({
   useNavigate: () => vi.fn(),
 }));
 
+vi.mock("../../ui/Container", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
 describe("TechnicalTestForm UI", () => {
   it("renders heading and back link", () => {
     render(<TechnicalTestForm />);


### PR DESCRIPTION
Se ha arreglado el problema por el que fallaban los tests del frontend: vitest no conseguía renderizar ciertos textos debido a la estructura del componente que usaban como contenedor, así que se ha reemplazado éste por un mock.