### PR TITLE
Feature/12 17 codeconnect member can leave project

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -685,6 +685,13 @@ class ListProjectsController extends Controller
             ], 404);
         }
 
+        if ($contributor->user_id !== auth()->id()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You are not allowed to remove this contributor'
+            ], 403);
+        }
+
         try {
             $contributor->delete();
 

--- a/backend/src/tests/Feature/ContributorTests/ContributorsCrudTest.php
+++ b/backend/src/tests/Feature/ContributorTests/ContributorsCrudTest.php
@@ -171,27 +171,6 @@ class ContributorsCrudTest extends TestCase
 
     // ========== DELETE TESTS ==========
 
-    public function test_it_can_delete_a_contributor_from_project(): void
-    {
-        $contributor = ContributorListProject::factory()->create([
-            'list_project_id' => $this->project->id,
-        ]);
-
-        Sanctum::actingAs($this->user);
-
-        $response = $this->deleteJson("/api/codeconnect/{$this->project->id}/contributors/{$contributor->id}");
-
-        $response->assertStatus(200)
-            ->assertJson([
-                'success' => true,
-                'message' => 'Contributor removed successfully',
-            ]);
-
-        $this->assertDatabaseMissing('contributors_list_project', [
-            'id' => $contributor->id,
-        ]);
-    }
-
     public function test_delete_returns_404_when_contributor_does_not_exist(): void
     {
         Sanctum::actingAs($this->user);
@@ -219,5 +198,55 @@ class ContributorsCrudTest extends TestCase
                 'success' => false,
                 'message' => 'Contributor not found',
             ]);
+    }
+
+    public function test_user_can_remove_himself_from_project(): void
+    {
+        $contributor = ContributorListProject::factory()->create([
+            'user_id' => $this->user->id,
+            'list_project_id' => $this->project->id,
+        ]);
+
+        Sanctum::actingAs($this->user);
+
+        $response = $this->deleteJson(
+            "/api/codeconnect/{$this->project->id}/contributors/{$contributor->id}"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'message' => 'Contributor removed successfully',
+            ]);
+
+        $this->assertDatabaseMissing('contributors_list_project', [
+            'id' => $contributor->id,
+        ]);
+    }
+
+    public function test_user_cannot_remove_another_contributor(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $contributor = ContributorListProject::factory()->create([
+            'user_id' => $otherUser->id,
+            'list_project_id' => $this->project->id,
+        ]);
+
+        Sanctum::actingAs($this->user);
+
+        $response = $this->deleteJson(
+            "/api/codeconnect/{$this->project->id}/contributors/{$contributor->id}"
+        );
+
+        $response->assertStatus(403)
+            ->assertJson([
+                'success' => false,
+                'message' => 'You are not allowed to remove this contributor',
+            ]);
+
+        $this->assertDatabaseHas('contributors_list_project', [
+            'id' => $contributor->id,
+        ]);
     }
 }


### PR DESCRIPTION
- Added conditional logic to allow contributors to remove only themselves from a project (self-removal).
- Implemented authorization check to ensure the authenticated user matches the contributor being removed.

Added feature tests to cover:
- Successful self-removal.
- Forbidden removal when attempting to delete another contributor.
- - Removed the generic delete contributor test, as it no longer aligns with the updated business rules.