### PR TITLE
Feature/15 only project member accept request

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -372,7 +372,7 @@ class ListProjectsController extends Controller
                 'message' => 'Contributor not found',
             ], 404);
         }
-        //
+        // 
         if($user) {
             $isMember = ContributorListProject::where('list_project_id', $listProjectId)
                 ->where('user_id', $user->id)

--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -372,6 +372,19 @@ class ListProjectsController extends Controller
                 'message' => 'Contributor not found',
             ], 404);
         }
+        //
+        if($user) {
+            $isMember = ContributorListProject::where('list_project_id', $listProjectId)
+                ->where('user_id', $user->id)
+                ->where('status', ContributorStatusEnum::Accepted->value)
+                ->exists();
+            
+            if (!$isMember) {
+                return response()->json([
+                    'error' => 'You cannot validate this request',
+                ], 403);
+            }
+        }
 
         //Only if is an authenticated user
         if ($user && $contributor->user_id === $user->id) {

--- a/backend/src/tests/Feature/ContributorTests/ValidateContributorStatusTest.php
+++ b/backend/src/tests/Feature/ContributorTests/ValidateContributorStatusTest.php
@@ -104,4 +104,39 @@ class ValidateContributorStatusTest extends TestCase
             'status' => ContributorStatusEnum::Pending->value,
         ]);
     }
+    public function test_only_acepted_contributors_can_validate_requests(){
+        $nonMemberUser = User::factory()->create();
+
+        /*ContributorListProject::factory()->create([
+            'list_project_id' => $this->project->id,
+            'user_id' => User::factory()->create() ->id,
+            'status' => ContributorStatusEnum::Accepted->value,
+        ]);*/
+        $contributorUser = User::factory()->create();
+        $pendingContributor = $this->createPendingContributor($contributorUser);
+
+        //dump for id comprove
+       /* dump([
+        'project_id' => $this->project->id,
+        'pending_contributor_id' => $pendingContributor->id,
+        'pending_contributor_list_project_id' => $pendingContributor->list_project_id,
+    ]);*/
+
+        $response = $this->actingAs($nonMemberUser, 'sanctum')
+            ->patchJson("/api/listsProject/{$this->project->id}/contributors/{$pendingContributor->id}/status", [
+                'status' => ContributorStatusEnum::Accepted->value,
+            ]);
+
+        dump($response->getContent());
+        
+        $response->assertStatus(403)
+            ->assertJson([
+                'error' => 'You cannot validate this request',
+            ]);
+
+        $this->assertDatabaseHas('contributors_list_project', [
+            'id' => $pendingContributor->id,
+            'status' => ContributorStatusEnum::Pending->value,
+        ]);
+    }
 }

--- a/backend/src/tests/Feature/ContributorTests/ValidateContributorStatusTest.php
+++ b/backend/src/tests/Feature/ContributorTests/ValidateContributorStatusTest.php
@@ -106,28 +106,13 @@ class ValidateContributorStatusTest extends TestCase
     }
     public function test_only_acepted_contributors_can_validate_requests(){
         $nonMemberUser = User::factory()->create();
-
-        /*ContributorListProject::factory()->create([
-            'list_project_id' => $this->project->id,
-            'user_id' => User::factory()->create() ->id,
-            'status' => ContributorStatusEnum::Accepted->value,
-        ]);*/
         $contributorUser = User::factory()->create();
         $pendingContributor = $this->createPendingContributor($contributorUser);
-
-        //dump for id comprove
-       /* dump([
-        'project_id' => $this->project->id,
-        'pending_contributor_id' => $pendingContributor->id,
-        'pending_contributor_list_project_id' => $pendingContributor->list_project_id,
-    ]);*/
 
         $response = $this->actingAs($nonMemberUser, 'sanctum')
             ->patchJson("/api/listsProject/{$this->project->id}/contributors/{$pendingContributor->id}/status", [
                 'status' => ContributorStatusEnum::Accepted->value,
             ]);
-
-        dump($response->getContent());
         
         $response->assertStatus(403)
             ->assertJson([


### PR DESCRIPTION
In this pull request, we ensure that only users who belong to the target project can accept or reject a join request. If the user is not a project member, an error message is returned.