### PR TITLE
fix: readapt tests to new component structure (orchestration)

### DIFF
--- a/frontend/src/components/technical-test/__test__/TechnicalTestForm.test.tsx
+++ b/frontend/src/components/technical-test/__test__/TechnicalTestForm.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { TechnicalTestForm } from "../TechnicalTestForm";
 import { vi } from "vitest";
 import "@testing-library/jest-dom";
+import { useForm } from "react-hook-form";
 
 vi.mock("react-router", () => ({
   useNavigate: () => vi.fn(),
@@ -11,6 +12,25 @@ vi.mock("react-router", () => ({
 
 vi.mock("../../ui/Container", () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../hooks/useTechnicalTestForm", () => ({
+  useTechnicalTestForm: () => ({
+    form: useForm({
+      defaultValues: {
+        title: "",
+        description: "",
+        language: undefined,
+        duration: undefined,
+        difficulty: "",
+        tags: [],
+        contentType: "text",
+        file: [],
+      },
+    }),
+    onSubmit: vi.fn(),
+    handleCancel: vi.fn(),
+  }),
 }));
 
 describe("TechnicalTestForm UI", () => {
@@ -51,7 +71,7 @@ describe("TechnicalTestForm UI", () => {
 
   it("renders duration input field", () => {
     render(<TechnicalTestForm />);
-    expect(screen.getByText("Durada (minuts)")).toBeInTheDocument();
+    expect(screen.getByText("Durada (minuts) *")).toBeInTheDocument();
     const durationInput = screen.getByRole("spinbutton");
     expect(durationInput).toBeInTheDocument();
     expect(durationInput).toHaveAttribute("type", "number");
@@ -72,7 +92,7 @@ describe("TechnicalTestForm UI", () => {
     const user = userEvent.setup();
     render(<TechnicalTestForm />);
 
-    const difficultySelect = screen.getByLabelText("Dificultat");
+    const difficultySelect = screen.getByRole("combobox");
     await user.selectOptions(difficultySelect, "hard");
 
     expect(difficultySelect).toHaveValue("hard");
@@ -80,26 +100,14 @@ describe("TechnicalTestForm UI", () => {
 
   it("renders difficulty select field with correct options", () => {
     render(<TechnicalTestForm />);
-    expect(screen.getByText("Dificultat")).toBeInTheDocument();
-    const difficultySelect = screen.getByLabelText("Dificultat");
+    expect(screen.getByText("Dificultat *")).toBeInTheDocument();
+    const difficultySelect = screen.getByRole("combobox");
     expect(difficultySelect).toBeInTheDocument();
-    expect(difficultySelect).toHaveValue("easy");
+    expect(difficultySelect).toHaveValue("");
 
     expect(screen.getByRole("option", { name: "Fàcil" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Mitjana" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Mitjà" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Difícil" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Expert" })).toBeInTheDocument();
-  });
-
-  it("renders exercises section with 4 textareas", () => {
-    render(<TechnicalTestForm />);
-    expect(screen.getByText("Exercicis")).toBeInTheDocument();
-
-    const exerciseTextareas = screen.getAllByPlaceholderText(/Exercici \d/);
-    expect(exerciseTextareas).toHaveLength(4);
-    expect(screen.getByPlaceholderText("Exercici 1")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Exercici 2")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Exercici 3")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Exercici 4")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Una vez realizado el merge con develop, se ha visto que los tests seguían fallando. Esto era debido a un desfase del componente TechnicalTestForm testeado entre la rama fix y develop. Se han reformulado los test, ahora sí, para adaptarlos a la nueva estructura.

<img width="926" height="497" alt="image" src="https://github.com/user-attachments/assets/57097e2b-5df1-4623-ab49-61dd1366a9d7" />