### PR TITLE
add empty state, error page to resources list

### DIFF
--- a/frontend/src/api/endPointResources.test.ts
+++ b/frontend/src/api/endPointResources.test.ts
@@ -60,7 +60,7 @@ describe("getResources", () => {
     );
   });
 
-  it("debería devolver los datos mockeados si la API devuelve un error", async () => {
+  it("debería lanzar error si la API devuelve un error HTTP", async () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({
         ok: false,
@@ -69,9 +69,9 @@ describe("getResources", () => {
       } as Response),
     );
 
-    const resources = await getResources();
-    expect(Array.isArray(resources)).toBe(true);
-    expect(resources).toHaveLength(0);
+    await expect(getResources()).rejects.toThrow(
+      "Error al obtener los recursos",
+    );
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/api/endPointResources.ts
+++ b/frontend/src/api/endPointResources.ts
@@ -20,7 +20,7 @@ const getResources = async (timeoutMs = 0): Promise<IntResource[]> => {
 
     if (!response.ok) {
       console.warn(`Error ${response.status}: ${response.statusText}`);
-      return [];
+      throw new Error(`Error ${response.status}: ${response.statusText}`);
     }
 
     const data = await response.json();

--- a/frontend/src/components/resources/ResourcesList.tsx
+++ b/frontend/src/components/resources/ResourcesList.tsx
@@ -55,16 +55,6 @@ export const ResourcesList: FC<ResourcesListProps> = ({
     );
   }, [sortedResources, searchTerm]);
 
-  if (showLoader) {
-    return (
-      <div className="flex flex-col gap-4 mt-10">
-        {Array.from({ length: 8 }).map((_, index) => (
-          <ResourceCardSkeleton key={index} />
-        ))}
-      </div>
-    );
-  }
-
   if (error) {
     return (
       <EmptyState
@@ -72,6 +62,16 @@ export const ResourcesList: FC<ResourcesListProps> = ({
         subtext="Hi ha hagut un problema. Torna-ho a provar."
         textClassName="text-red-500"
       />
+    );
+  }
+
+  if (showLoader) {
+    return (
+      <div className="flex flex-col gap-4 mt-10">
+        {Array.from({ length: 8 }).map((_, index) => (
+          <ResourceCardSkeleton key={index} />
+        ))}
+      </div>
     );
   }
 

--- a/frontend/src/components/resources/ResourcesList.tsx
+++ b/frontend/src/components/resources/ResourcesList.tsx
@@ -24,7 +24,7 @@ export const ResourcesList: FC<ResourcesListProps> = ({
   const searchTerm = searchParams.get("search") || "";
 
   const { selectedResourceTypes, selectedTags } = useResourcesFilters();
-  const { isBookmarked, toggleBookmark, isLoading, error } = useResources();
+  const { isBookmarked, toggleBookmark, isLoading } = useResources();
 
   const showLoader = useMinLoading(isLoading, 1500);
 
@@ -66,16 +66,6 @@ export const ResourcesList: FC<ResourcesListProps> = ({
           <ResourceCardSkeleton key={index} />
         ))}
       </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <EmptyState
-        text="Error al obtenir recursos"
-        subtext="Hi ha hagut un problema. Torna-ho a provar."
-        textClassName="text-red-500"
-      />
     );
   }
 

--- a/frontend/src/components/resources/ResourcesList.tsx
+++ b/frontend/src/components/resources/ResourcesList.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import { IntResource } from "../../types";
 import { useResourceFilter } from "../../hooks/useResourceFilter";
@@ -26,9 +26,10 @@ export const ResourcesList: FC<ResourcesListProps> = ({
   const { selectedResourceTypes, selectedTags } = useResourcesFilters();
   const { isBookmarked, toggleBookmark, isLoading } = useResources();
 
+  const [error] = useState<Error | null>(null);
+
   const showLoader = useMinLoading(isLoading, 1500);
 
-  // Filter resources by category
   const categoryFilteredResources = useMemo(() => {
     if (!resources?.length) return [];
 
@@ -37,19 +38,16 @@ export const ResourcesList: FC<ResourcesListProps> = ({
       : resources;
   }, [resources, category]);
 
-  // Apply filters
   const { filteredResources } = useResourceFilter({
     resources: categoryFilteredResources,
     selectedResourceTypes,
     selectedTags,
   });
 
-  // Apply sorting
   const { sortedResources, setSortOption, sortOption } = useResourceSort({
     resources: filteredResources,
   });
 
-  // Apply search filter
   const visibleResources = useMemo(() => {
     if (!searchTerm) return sortedResources;
 
@@ -69,6 +67,16 @@ export const ResourcesList: FC<ResourcesListProps> = ({
     );
   }
 
+  if (error) {
+    return (
+      <EmptyState
+        text="Error al obtenir recursos"
+        subtext="Hi ha hagut un problema. Torna-ho a provar."
+        textClassName="text-red-500"
+      />
+    );
+  }
+
   if (!resources?.length) {
     return (
       <EmptyState
@@ -81,11 +89,9 @@ export const ResourcesList: FC<ResourcesListProps> = ({
   return (
     <div className="lg:flex-1">
       <div className="flex justify-end items-center">
-        {/* El encabezado se eliminó de aquí */}
         <SortButton setSortOption={setSortOption} sortOption={sortOption} />
       </div>
 
-      {/* Resources List */}
       {visibleResources.length === 0 ? (
         <div className="flex flex-col gap-4 py-8">
           <div className="text-center py-8 text-gray-500">

--- a/frontend/src/components/resources/ResourcesList.tsx
+++ b/frontend/src/components/resources/ResourcesList.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { IntResource } from "../../types";
 import { useResourceFilter } from "../../hooks/useResourceFilter";
@@ -24,9 +24,7 @@ export const ResourcesList: FC<ResourcesListProps> = ({
   const searchTerm = searchParams.get("search") || "";
 
   const { selectedResourceTypes, selectedTags } = useResourcesFilters();
-  const { isBookmarked, toggleBookmark, isLoading } = useResources();
-
-  const [error] = useState<Error | null>(null);
+  const { isBookmarked, toggleBookmark, isLoading, error } = useResources();
 
   const showLoader = useMinLoading(isLoading, 1500);
 

--- a/frontend/src/components/resources/ResourcesList.tsx
+++ b/frontend/src/components/resources/ResourcesList.tsx
@@ -9,6 +9,7 @@ import ResourceCard from "../ui/ResourceCard";
 import ResourceCardSkeleton from "./ResourcesSkeleton";
 import SortButton from "./SortButton";
 import { useMinLoading } from "../../hooks/useMinLoading";
+import EmptyState from "../ui/EmptyState";
 
 interface ResourcesListProps {
   resources: IntResource[];
@@ -23,7 +24,7 @@ export const ResourcesList: FC<ResourcesListProps> = ({
   const searchTerm = searchParams.get("search") || "";
 
   const { selectedResourceTypes, selectedTags } = useResourcesFilters();
-  const { isBookmarked, toggleBookmark, isLoading } = useResources();
+  const { isBookmarked, toggleBookmark, isLoading, error } = useResources();
 
   const showLoader = useMinLoading(isLoading, 1500);
 
@@ -67,12 +68,23 @@ export const ResourcesList: FC<ResourcesListProps> = ({
       </div>
     );
   }
-  // Early return if no resources
+
+  if (error) {
+    return (
+      <EmptyState
+        text="Error al obtenir recursos"
+        subtext="Hi ha hagut un problema. Torna-ho a provar."
+        textClassName="text-red-500"
+      />
+    );
+  }
+
   if (!resources?.length) {
     return (
-      <div className="text-center py-8 text-gray-500">
-        No hi ha recursos disponibles.
-      </div>
+      <EmptyState
+        text="No hi ha recursos"
+        subtext="Torna-ho a provar més tard"
+      />
     );
   }
 

--- a/frontend/src/components/resources/__test__/ListMyResources.test.tsx
+++ b/frontend/src/components/resources/__test__/ListMyResources.test.tsx
@@ -1,87 +1,180 @@
 import { render, screen } from "@testing-library/react";
-import { vi, describe, test, expect } from "vitest";
-import { ListMyResources } from "../ListMyResources";
+import { MemoryRouter } from "react-router";
+import { ResourcesLayout } from "../ResourcesLayout";
+import { ResourcesList } from "../ResourcesList";
+import { ResourcesFiltersProvider } from "../../../context/ResourcesFiltersContext";
+import { categories } from "../../../data/categories";
 import { IntResource } from "../../../types";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("../../ui/ResourceCard", () => ({
-  default: vi.fn(({ resource }) => (
-    <li data-testid={`resource-card-${resource.id}`}>
-      <div>{resource.title}</div>
-      <div>{resource.description}</div>
-    </li>
-  )),
-}));
-
-vi.mock("../../../context/UserContext", () => ({
-  useUserContext: vi.fn().mockReturnValue({
-    user: { id: "user123" },
-    isAuthenticated: true,
-    signIn: vi.fn(),
-    signOut: vi.fn(),
-    error: null,
-    setError: vi.fn(),
-    saveUser: vi.fn(),
+vi.mock("../../../hooks/useResourceFilter", () => ({
+  useResourceFilter: () => ({
+    filteredResources: mockResources,
+    selectedTags: [],
+    setSelectedTags: vi.fn(),
+    selectedResourceTypes: ["Video"],
+    setSelectedResourceTypes: vi.fn(),
   }),
 }));
 
-describe("ListMyResources Component", () => {
-  const mockBase = [
-    {
-      id: 1,
-      title: "React Basics",
-      description: "Learn React fundamentals",
-      type: "Blog",
+vi.mock("../../../context/UserContext", () => ({
+  useUserContext: () => ({
+    user: { id: "123463" },
+  }),
+}));
+
+const mockUseMinLoading = vi.fn();
+
+vi.mock("../../../hooks/useMinLoading", () => ({
+  useMinLoading: () => mockUseMinLoading(),
+}));
+
+const mockUseResources = vi.fn();
+
+vi.mock("../../../context/ResourcesContext", () => ({
+  useResources: () => mockUseResources(),
+}));
+
+const mockResources: IntResource[] = [
+  {
+    id: 1,
+    title: "React Basics",
+    description: "Learn React step-by-step",
+    type: "Video",
+    created_at: "2025-02-25 00:00:00",
+    updated_at: "2025-02-25 00:00:00",
+    like_count: 10,
+    bookmark_count: 2,
+    comment_count: 1,
+  } as IntResource,
+  {
+    id: 2,
+    title: "Advanced JS",
+    description: "Deep dive into JS",
+    type: "Blog",
+    created_at: "2025-02-25 00:00:00",
+    updated_at: "2025-02-25 00:00:00",
+    like_count: 5,
+    bookmark_count: 0,
+    comment_count: 0,
+  } as IntResource,
+];
+
+const category = Object.keys(categories)[0] as keyof typeof categories;
+
+const setupLoadingState = (isLoading: boolean) => {
+  mockUseMinLoading.mockReturnValue(isLoading);
+  mockUseResources.mockReturnValue({
+    isBookmarked: vi.fn(),
+    toggleBookmark: vi.fn(),
+    resources: mockResources,
+    isLoading,
+    getBookmarkCount: (resourceId: number | string) => {
+      const resource = mockResources.find((r) => r.id === resourceId);
+      return resource?.bookmark_count || 0;
     },
-    {
-      id: 2,
-      title: "Advanced TypeScript",
-      description: "Master TypeScript concepts",
-      type: "Video",
-    },
-  ];
+    bookmarkedResources: [],
+    loadingBookmarks: false,
+  });
+};
 
-  const mockResources = mockBase.map(
-    (resource) =>
-      ({
-        ...resource,
-      }) as IntResource,
-  );
+describe("ResourcesLayout Component", () => {
+  beforeEach(() => {
+    setupLoadingState(false);
+  });
+  it("should render the component and display the correct title", () => {
+    render(
+      <MemoryRouter>
+        <ResourcesFiltersProvider>
+          <ResourcesLayout
+            resources={mockResources}
+            category={String(category)}
+          />
+        </ResourcesFiltersProvider>
+      </MemoryRouter>,
+    );
 
-  test("renders correctly with my resources", () => {
-    render(<ListMyResources myResources={mockResources} />);
+    const titleElement = screen.getByText(`Recursos ${String(category)}`);
+    expect(titleElement.tagName).toBe("H2");
+  });
 
-    expect(screen.getByTestId("resource-card-1")).toBeInTheDocument();
-    expect(screen.getByTestId("resource-card-2")).toBeInTheDocument();
+  it("should render 8 skeletons when loading", () => {
+    setupLoadingState(true);
 
+    render(
+      <MemoryRouter>
+        <ResourcesFiltersProvider>
+          <ResourcesList
+            resources={mockResources}
+            category={String(category)}
+          />
+        </ResourcesFiltersProvider>
+      </MemoryRouter>,
+    );
+
+    const skeletons = screen.getAllByTestId("resource-card-skeleton");
+    expect(skeletons).toHaveLength(8);
+    expect(screen.queryByText("React Basics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Advanced JS")).not.toBeInTheDocument();
+  });
+
+  it("should hide skeletons after loading completes", () => {
+    setupLoadingState(true);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <ResourcesFiltersProvider>
+          <ResourcesList
+            resources={mockResources}
+            category={String(category)}
+          />
+        </ResourcesFiltersProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByTestId("resource-card-skeleton")).toHaveLength(8);
+
+    // Simular que termina la carga
+    setupLoadingState(false);
+
+    rerender(
+      <MemoryRouter>
+        <ResourcesFiltersProvider>
+          <ResourcesList
+            resources={mockResources}
+            category={String(category)}
+          />
+        </ResourcesFiltersProvider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByTestId("resource-card-skeleton"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("React Basics")).toBeInTheDocument();
-    expect(screen.getByText("Advanced TypeScript")).toBeInTheDocument();
+    expect(screen.getByText("Advanced JS")).toBeInTheDocument();
   });
 
-  test("renders empty list when no resources", () => {
-    render(<ListMyResources myResources={[]} />);
+  it("muestra EmptyState cuando no hay recursos", () => {
+    mockUseMinLoading.mockReturnValue(false);
+    mockUseResources.mockReturnValue({
+      isBookmarked: vi.fn(),
+      toggleBookmark: vi.fn(),
+      resources: [],
+      isLoading: false,
+      getBookmarkCount: () => 0,
+      bookmarkedResources: [],
+      loadingBookmarks: false,
+    });
 
-    const list = screen.getByRole("list");
-    expect(list).toBeInTheDocument();
-    expect(list.children).toHaveLength(0);
-  });
+    render(
+      <MemoryRouter>
+        <ResourcesFiltersProvider>
+          <ResourcesList resources={[]} category={String(category)} />
+        </ResourcesFiltersProvider>
+      </MemoryRouter>,
+    );
 
-  test("renders the correct number of resources", () => {
-    const manyResources = Array.from({ length: 5 }, (_, index) => ({
-      ...mockBase[0],
-      id: index + 1,
-      title: `Resource ${index + 1}`,
-      created_at: "2025-02-25 00:00:00",
-      updated_at: "2025-02-25 00:00:00",
-    })) as IntResource[];
-
-    render(<ListMyResources myResources={manyResources} />);
-
-    const list = screen.getByRole("list");
-    expect(list.children).toHaveLength(5);
-
-    for (let i = 1; i <= 5; i++) {
-      expect(screen.getByTestId(`resource-card-${i}`)).toBeInTheDocument();
-      expect(screen.getByText(`Resource ${i}`)).toBeInTheDocument();
-    }
+    expect(screen.getByText("No hi ha recursos")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/resources/__test__/ListResources.test.tsx
+++ b/frontend/src/components/resources/__test__/ListResources.test.tsx
@@ -75,6 +75,7 @@ const setupLoadingState = (isLoading: boolean) => {
     },
     bookmarkedResources: [],
     loadingBookmarks: false,
+    error: null,
   });
 };
 
@@ -153,5 +154,29 @@ describe("ResourcesLayout Component", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText("React Basics")).toBeInTheDocument();
     expect(screen.getByText("Advanced JS")).toBeInTheDocument();
+  });
+
+  it("muestra EmptyState cuando no hay recursos", () => {
+    mockUseMinLoading.mockReturnValue(false);
+    mockUseResources.mockReturnValue({
+      isBookmarked: vi.fn(),
+      toggleBookmark: vi.fn(),
+      resources: [],
+      isLoading: false,
+      getBookmarkCount: () => 0,
+      bookmarkedResources: [],
+      loadingBookmarks: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <ResourcesFiltersProvider>
+          <ResourcesList resources={[]} category={String(category)} />
+        </ResourcesFiltersProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("No hi ha recursos")).toBeInTheDocument();
   });
 });

--- a/frontend/src/context/ResourcesContext.tsx
+++ b/frontend/src/context/ResourcesContext.tsx
@@ -9,6 +9,7 @@ import { canBookmark } from "../data/permission/tempRolesPremission";
 interface ResourcesContextType {
   resources: IntResource[];
   isLoading: boolean;
+  error: Error | null;
   bookmarkedResources: IntBookmarkElement[];
   loadingBookmarks: boolean;
   isBookmarked: (resource: IntResource) => boolean;
@@ -21,6 +22,7 @@ interface ResourcesContextType {
 const ResourcesContext = createContext<ResourcesContextType>({
   resources: [],
   isLoading: true,
+  error: null,
   bookmarkedResources: [],
   loadingBookmarks: true,
   isBookmarked: () => false,
@@ -40,6 +42,7 @@ export const ResourcesProvider = ({
   const { user } = useUserContext();
   const [resources, setResources] = useState<IntResource[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
   const [bookmarkedResources, setBookmarkedResources] = useState<
     IntBookmarkElement[]
   >([]);
@@ -63,6 +66,7 @@ export const ResourcesProvider = ({
         setBookmarkCounts(initialCounts);
       } catch (err) {
         console.error("Error loading resources:", err);
+        setError(err as Error);
       } finally {
         setIsLoading(false);
       }
@@ -222,6 +226,7 @@ export const ResourcesProvider = ({
       value={{
         resources,
         isLoading,
+        error,
         bookmarkedResources,
         loadingBookmarks,
         isBookmarked,


### PR DESCRIPTION
Before:
Loading: Skeletons
Error: It does not persist it in state, nor does it expose it to components
No data: Nothing displayed

After:

Loading: resources skeletons displayed
Error: 
No data: EmptyState displayed with error
Data available: resources project list displayed

<img width="1548" height="836" alt="Screenshot 2026-02-03 at 10 21 36 a m" src="https://github.com/user-attachments/assets/98bbb137-0b51-48fc-9d6c-4ce7dd7db668" />
