### PR TITLE
Feature/126 language tag bar technical list

### DIFF
--- a/frontend/src/components/technical-test/LanguageTagsBar.tsx
+++ b/frontend/src/components/technical-test/LanguageTagsBar.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { contentForTechnicalTest } from "./languageLabelsContent";
+
+interface LanguageTagsBarProps {
+  initialSelected?: string | null;
+  onSelect?: (language: string | null) => void;
+}
+
+const LanguageTagsBar = ({
+  initialSelected = null,
+  onSelect,
+}: LanguageTagsBarProps) => {
+  const [selected, setSelected] = useState<string | null>(initialSelected);
+
+  const handleClick = (language: string) => {
+    const newSelected = selected === language ? null : language;
+    setSelected(newSelected);
+    onSelect?.(newSelected);
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {contentForTechnicalTest.map(({ label }) => (
+        <button
+          key={label}
+          onClick={() => handleClick(label)}
+          className={`px-5 py-2 rounded-full border text-sm transition-colors
+            ${
+              selected === label
+                ? "bg-black text-white border-black"
+                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-100"
+            }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default LanguageTagsBar;

--- a/frontend/src/components/technical-test/LanguageTagsBar.tsx
+++ b/frontend/src/components/technical-test/LanguageTagsBar.tsx
@@ -24,7 +24,7 @@ const LanguageTagsBar = ({
         <button
           key={label}
           onClick={() => handleClick(label)}
-          className={`px-5 py-2 rounded-full border text-sm transition-colors
+          className={`px-5 py-2 rounded-full border text-sm transition-colors cursor-pointer
             ${
               selected === label
                 ? "bg-black text-white border-black"

--- a/frontend/src/components/technical-test/TechnicalTestsHeader.tsx
+++ b/frontend/src/components/technical-test/TechnicalTestsHeader.tsx
@@ -1,7 +1,4 @@
-import { useState } from "react";
 import LanguageTagsBar from "./LanguageTagsBar";
-
-type OpenDropdown = "sort" | "filters" | null;
 
 interface TechnicalTestsHeaderProps {
   initialCategory?: string;
@@ -12,53 +9,15 @@ const TechnicalTestsHeader = ({
   initialCategory,
   onCategoryChange,
 }: TechnicalTestsHeaderProps) => {
-  const [openDropdown, setOpenDropdown] = useState<OpenDropdown>(null);
-
   return (
     <div className="flex justify-between items-start mb-6">
       <LanguageTagsBar
         initialSelected={initialCategory ?? null}
         onSelect={onCategoryChange}
       />
-      <div className="flex gap-2">
-        <div className="relative">
-          <button
-            onClick={() =>
-              setOpenDropdown(openDropdown === "sort" ? null : "sort")
-            }
-            className="px-4 py-2 border border-gray-300 rounded bg-white text-gray-700 hover:bg-gray-50 flex items-center gap-2"
-          >
-            Ordenar
-            <span className="text-xs">▼</span>
-          </button>
-          {openDropdown === "sort" && (
-            <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-10 overflow-hidden">
-              <p className="text-sm text-gray-400 text-center py-4">
-                Pròximament
-              </p>
-            </div>
-          )}
-        </div>
 
-        <div className="relative">
-          <button
-            onClick={() =>
-              setOpenDropdown(openDropdown === "filters" ? null : "filters")
-            }
-            className="px-4 py-2 border border-gray-300 rounded bg-white text-gray-700 hover:bg-gray-50 flex items-center gap-2"
-          >
-            Filtres
-            <span className="text-xs">▼</span>
-          </button>
-          {openDropdown === "filters" && (
-            <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-10 overflow-hidden">
-              <p className="text-sm text-gray-400 text-center py-4">
-                Pròximament
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
+      {/* Botons d'acció — pendents d'implementar */}
+      <div />
     </div>
   );
 };

--- a/frontend/src/components/technical-test/__test__/LanguageTagsBar.test.tsx
+++ b/frontend/src/components/technical-test/__test__/LanguageTagsBar.test.tsx
@@ -1,0 +1,82 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import LanguageTagsBar from "../LanguageTagsBar";
+import { contentForTechnicalTest } from "../languageLabelsContent";
+
+const languages = contentForTechnicalTest.map((item) => item.label);
+
+describe("LanguageTagsBar (TechnicalTest)", () => {
+  it("renders all language buttons", () => {
+    render(<LanguageTagsBar />);
+
+    languages.forEach((language) => {
+      expect(screen.getByText(language)).toBeInTheDocument();
+    });
+  });
+
+  it("renders the correct number of language buttons", () => {
+    render(<LanguageTagsBar />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(languages.length);
+  });
+
+  it("shows initial selected language with active styles", () => {
+    render(<LanguageTagsBar initialSelected="React" />);
+
+    const reactButton = screen.getByText("React");
+    expect(reactButton).toHaveClass("bg-black", "text-white");
+  });
+
+  it("selects a language on click", () => {
+    render(<LanguageTagsBar />);
+
+    const jsButton = screen.getByText("JavaScript");
+    fireEvent.click(jsButton);
+
+    expect(jsButton).toHaveClass("bg-black", "text-white");
+  });
+
+  it("deselects language on second click", () => {
+    render(<LanguageTagsBar />);
+
+    const javaButton = screen.getByText("Java");
+    fireEvent.click(javaButton);
+    expect(javaButton).toHaveClass("bg-black", "text-white");
+
+    fireEvent.click(javaButton);
+    expect(javaButton).toHaveClass("bg-white", "text-gray-700");
+  });
+
+  it("calls onSelect with language name when selected", () => {
+    const mockOnSelect = vi.fn();
+    render(<LanguageTagsBar onSelect={mockOnSelect} />);
+
+    const pythonButton = screen.getByText("Python");
+    fireEvent.click(pythonButton);
+
+    expect(mockOnSelect).toHaveBeenCalledWith("Python");
+  });
+
+  it("calls onSelect with null when deselected", () => {
+    const mockOnSelect = vi.fn();
+    render(<LanguageTagsBar initialSelected="PHP" onSelect={mockOnSelect} />);
+
+    const phpButton = screen.getByText("PHP");
+    fireEvent.click(phpButton);
+
+    expect(mockOnSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("only one language can be selected at a time", () => {
+    render(<LanguageTagsBar initialSelected="React" />);
+
+    const sqlButton = screen.getByText("SQL");
+    fireEvent.click(sqlButton);
+
+    const reactButton = screen.getByText("React");
+    expect(sqlButton).toHaveClass("bg-black", "text-white");
+    expect(reactButton).toHaveClass("bg-white", "text-gray-700");
+  });
+});

--- a/frontend/src/components/technical-test/__test__/TechnicalTestList.test.tsx
+++ b/frontend/src/components/technical-test/__test__/TechnicalTestList.test.tsx
@@ -61,7 +61,6 @@ describe("TechnicalTestList", () => {
     });
   });
 
-<<<<<<< 126-language-tag-bar-technical-list
   it("filters by language when language prop is provided", () => {
     render(
       <MemoryRouter>
@@ -125,9 +124,6 @@ describe("TechnicalTestList", () => {
 
     expect(screen.getByText("No hi ha proves tècniques")).toBeDefined();
   });
-
-=======
->>>>>>> develop
   it("shows EmptyState with error styling when there is an error", () => {
     mockedUseTechnicalTestList.mockReturnValue({
       technicalTests: [],

--- a/frontend/src/components/technical-test/__test__/TechnicalTestList.test.tsx
+++ b/frontend/src/components/technical-test/__test__/TechnicalTestList.test.tsx
@@ -61,82 +61,36 @@ describe("TechnicalTestList", () => {
     });
   });
 
-  it("The title 'Proves tècniques' must be displayed", () => {
+  it("filters by language when language prop is provided", () => {
+    render(
+      <MemoryRouter>
+        <TechnicalTestList language="JavaScript" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Test A")).toBeDefined();
+    expect(screen.queryByText("Test B")).toBeNull();
+  });
+
+  it("shows all tests when no language prop is provided", () => {
     render(
       <MemoryRouter>
         <TechnicalTestList />
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("Proves tècniques")).toBeDefined();
-  });
-
-  it("filters by language when filters are provided", () => {
-    render(
-      <MemoryRouter>
-        <TechnicalTestList
-          filters={{
-            languages: ["JavaScript"],
-            years: [],
-            difficulties: [],
-          }}
-        />
-      </MemoryRouter>,
-    );
-
     expect(screen.getByText("Test A")).toBeDefined();
-    expect(screen.queryByText("Test B")).toBeNull();
-  });
-
-  it("filters by year when filters are provided", () => {
-    render(
-      <MemoryRouter>
-        <TechnicalTestList
-          filters={{
-            languages: [],
-            years: ["2024"],
-            difficulties: [],
-          }}
-        />
-      </MemoryRouter>,
-    );
-
     expect(screen.getByText("Test B")).toBeDefined();
-    expect(screen.queryByText("Test A")).toBeNull();
   });
 
-  it("filters by difficulty (Bàsica -> easy)", () => {
+  it("shows EmptyState when language filter returns no results", () => {
     render(
       <MemoryRouter>
-        <TechnicalTestList
-          filters={{
-            languages: [],
-            years: [],
-            difficulties: ["Bàsica"],
-          }}
-        />
+        <TechnicalTestList language="Python" />
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("Test A")).toBeDefined();
-    expect(screen.queryByText("Test B")).toBeNull();
-  });
-
-  it("filters by difficulty (Difícil -> hard)", () => {
-    render(
-      <MemoryRouter>
-        <TechnicalTestList
-          filters={{
-            languages: [],
-            years: [],
-            difficulties: ["Difícil"],
-          }}
-        />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("Test B")).toBeDefined();
-    expect(screen.queryByText("Test A")).toBeNull();
+    expect(screen.getByText("No hi ha proves tècniques")).toBeDefined();
   });
 
   it("shows error message when there is an error", () => {
@@ -165,22 +119,6 @@ describe("TechnicalTestList", () => {
     render(
       <MemoryRouter>
         <TechnicalTestList />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("No hi ha proves tècniques")).toBeDefined();
-  });
-
-  it("shows EmptyState when filters return no results", () => {
-    render(
-      <MemoryRouter>
-        <TechnicalTestList
-          filters={{
-            languages: ["Python"],
-            years: [],
-            difficulties: [],
-          }}
-        />
       </MemoryRouter>,
     );
 

--- a/frontend/src/components/technical-test/__test__/TechnicalTestsHeader.test.tsx
+++ b/frontend/src/components/technical-test/__test__/TechnicalTestsHeader.test.tsx
@@ -1,0 +1,33 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import TechnicalTestsHeader from "../TechnicalTestsHeader";
+import { contentForTechnicalTest } from "../languageLabelsContent";
+
+const firstLanguage = contentForTechnicalTest[0].label;
+
+describe("TechnicalTestsHeader", () => {
+  it("renders the LanguageTagsBar", () => {
+    render(<TechnicalTestsHeader />);
+    expect(screen.getByText(firstLanguage)).toBeInTheDocument();
+  });
+
+  it("calls onCategoryChange when a language is selected", () => {
+    const mockOnChange = vi.fn();
+    render(<TechnicalTestsHeader onCategoryChange={mockOnChange} />);
+    fireEvent.click(screen.getByText(firstLanguage));
+    expect(mockOnChange).toHaveBeenCalledWith(firstLanguage);
+  });
+
+  it("calls onCategoryChange with null when language is deselected", () => {
+    const mockOnChange = vi.fn();
+    render(
+      <TechnicalTestsHeader
+        initialCategory="React"
+        onCategoryChange={mockOnChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("React"));
+    expect(mockOnChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/src/pages/MyTechnicalTestsPage.tsx
+++ b/frontend/src/pages/MyTechnicalTestsPage.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 
 import TechnicalTestFilter from "../components/technical-test/TechnicalTestFilter";
 import TechnicalTestList from "../components/technical-test/TechnicalTestList";
+import LanguageTagsBar from "../components/technical-test/LanguageTagsBar";
 import Container from "../components/ui/Container";
 
 type TechnicalTestsFiltersState = {
@@ -17,11 +18,18 @@ function MyTechnicalTestsPage() {
   const location = useLocation();
   const toastShown = useRef(false);
 
-  const [filters, setFilters] = useState<TechnicalTestsFiltersState>({
-    languages: [],
+  const [languageFilter, setLanguageFilter] = useState<string | null>(null);
+  const [otherFilters, setOtherFilters] = useState<
+    Pick<TechnicalTestsFiltersState, "years" | "difficulties">
+  >({
     years: [],
     difficulties: [],
   });
+
+  const filters: TechnicalTestsFiltersState = {
+    languages: languageFilter ? [languageFilter] : [],
+    ...otherFilters,
+  };
 
   useEffect(() => {
     if (location.state?.successMessage && !toastShown.current) {
@@ -33,11 +41,15 @@ function MyTechnicalTestsPage() {
 
   return (
     <Container>
+      <div className="mb-6">
+        <LanguageTagsBar onSelect={setLanguageFilter} />
+      </div>
       <div className="flex flex-col md:flex-row">
-        {}
-        <TechnicalTestFilter onFiltersChange={setFilters} />
-
-        {}
+        <TechnicalTestFilter
+          onFiltersChange={({ years, difficulties }) =>
+            setOtherFilters({ years, difficulties })
+          }
+        />
         <TechnicalTestList filters={filters} />
       </div>
     </Container>


### PR DESCRIPTION
This PR implements the `LanguageTagsBar` component for the Technical Tests page, allowing users to filter tests by programming language using pill-style toggle buttons.

Note on merge dependency
In order to meet the deadline, this branch includes a merge from [refactor(technicaltesrCard)--update-layout-to-match-new-layout,](https://github.com/IT-Academy-BCN/ita-wiki-monorepo/pull/134) which has not yet been approved or merged into develop.
Before:
<img width="2896" height="1748" alt="image" src="https://github.com/user-attachments/assets/058768a1-e5bc-4b94-a868-829b2a21fa3a" />


After:
<img width="1695" height="938" alt="Captura de pantalla 2026-02-23 a las 11 56 07" src="https://github.com/user-attachments/assets/68d4b708-3815-478c-bdec-faadcf1f1f80" />


