### PR TITLE
Return specific messages for owner-related contributor attempts

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -629,6 +629,20 @@ class ListProjectsController extends Controller
             ], 404);
         }
 
+        if (auth()->id() === $project->owner_id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You are the owner of this project'
+            ], 403);
+        }
+
+        if ($validatedData['user_id'] === $project->owner_id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'The owner cannot be added as a contributor'
+            ], 403);
+        }
+
         $existingContributor = ContributorListProject::where('list_project_id', $listProjectId)
             ->where('user_id', $validatedData['user_id'])
             ->first();

--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -629,7 +629,7 @@ class ListProjectsController extends Controller
             ], 404);
         }
 
-        if (auth()->id() === $project->owner_id) {
+        if (auth()->id() === $project->owner_id && $validatedData['user_id'] === $project->owner_id) {
             return response()->json([
                 'success' => false,
                 'message' => 'You are the owner of this project'
@@ -642,6 +642,7 @@ class ListProjectsController extends Controller
                 'message' => 'The owner cannot be added as a contributor'
             ], 403);
         }
+
 
         $existingContributor = ContributorListProject::where('list_project_id', $listProjectId)
             ->where('user_id', $validatedData['user_id'])

--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -629,14 +629,14 @@ class ListProjectsController extends Controller
             ], 404);
         }
 
-        if (auth()->id() === $project->owner_id && $validatedData['user_id'] === $project->owner_id) {
+        if (auth()->id() === $project->user_id && $validatedData['user_id'] === $project->user_id) {
             return response()->json([
                 'success' => false,
                 'message' => 'You are the owner of this project'
             ], 403);
         }
 
-        if ($validatedData['user_id'] === $project->owner_id) {
+        if ($validatedData['user_id'] === $project->user_id) {
             return response()->json([
                 'success' => false,
                 'message' => 'The owner cannot be added as a contributor'

--- a/backend/src/tests/Feature/ContributorTests/ContributorsCrudTest.php
+++ b/backend/src/tests/Feature/ContributorTests/ContributorsCrudTest.php
@@ -350,4 +350,42 @@ class ContributorsCrudTest extends TestCase
             ]);
     }
 
+    public function test_owner_cannot_join_their_own_project(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        Sanctum::actingAs($owner);
+
+        $response = $this->postJson("/api/codeconnect/{$project->id}/contributors", [
+            'user_id' => $owner->id,
+            'programming_role' => 'Backend Developer',
+        ]);
+
+        $response->assertStatus(403)
+            ->assertJson([
+                'success' => false,
+                'message' => 'You are the owner of this project',
+            ]);
+    }
+
+    public function test_owner_cannot_be_added_as_contributor(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        Sanctum::actingAs($this->user);
+
+        $response = $this->postJson("/api/codeconnect/{$project->id}/contributors", [
+            'user_id' => $owner->id,
+            'programming_role' => 'Frontend Developer',
+        ]);
+
+        $response->assertStatus(403)
+            ->assertJson([
+                'success' => false,
+                'message' => 'The owner cannot be added as a contributor',
+            ]);
+    }
+
 }


### PR DESCRIPTION
When the owner tried to join their own project or someone attempted to add 
the owner as a contributor, the API returned a generic "already a contributor" 
message, which was confusing and didn't explain the actual reason.

This PR adds two specific validations in addContributor():
- If the authenticated user is the owner, they get a clear message that 
  they already own the project.
- If someone tries to add the owner as a contributor, they get a message 
  explaining that the owner cannot be added.

This also resolves the root cause of the join error reported in #151.