### PR TITLE
Remove 4th difficulty level ("expert")

### DIFF
--- a/backend/src/app/Enums/DifficultyLevelEnum.php
+++ b/backend/src/app/Enums/DifficultyLevelEnum.php
@@ -9,7 +9,6 @@ enum DifficultyLevelEnum: string
     case Easy = 'easy';
     case Medium = 'medium';
     case Hard = 'hard';
-    case Expert = 'expert';
 
     public static function values(): array
     {


### PR DESCRIPTION
I have removed the “expert” difficulty level from the enum list so that it will no longer be considered.