### PR TITLE
Add ability to create a ticket linked to a forum answer

### DIFF
--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -36,7 +36,7 @@ class TicketController extends Controller{
     public function store(CreateTicketRequest $request): JsonResponse{
 
         $ticket = Ticket::create($request->validated());
-
+        
         return response()->json([
             'success' => true,
             'message' => 'The Ticket has been created correctly',

--- a/backend/src/app/Http/Requests/Tickets/CreateTicketRequest.php
+++ b/backend/src/app/Http/Requests/Tickets/CreateTicketRequest.php
@@ -14,6 +14,7 @@ class CreateTicketRequest extends FormRequest{
 
         return [
             'code_connect_id' => 'required|integer|exists:users,id',
+            'forum_answer_id' => 'nullable|integer|exists:forum_answers,id',
             'assignee_id' => 'nullable|integer|exists:users,id',
             'name' => 'required|string|max:255',
             'incident_date' => 'required|date',
@@ -24,5 +25,3 @@ class CreateTicketRequest extends FormRequest{
         ];
     }
 }
-
-?>

--- a/backend/src/app/Models/Ticket.php
+++ b/backend/src/app/Models/Ticket.php
@@ -13,7 +13,7 @@ use App\Enums\TicketTypeEnum;
 use App\Enums\TicketPriorityEnum;
 use App\Enums\AffectedAppEnum;
 use App\Enums\AffectedFunctionEnum;
-
+use App\Models\ForumAnswer;
 class Ticket extends Model
 {
     /** @use HasFactory<\Database\Factories\TicketFactory> */
@@ -21,6 +21,7 @@ class Ticket extends Model
 
     protected $fillable = [
         'code_connect_id',
+        'forum_answer_id',
         'name',
         'incident_date',
         'affected_app',
@@ -62,6 +63,10 @@ class Ticket extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(TicketComment::class);
+    }
+    public function forumAnswer(): BelongsTo
+    {
+        return $this->belongsTo(ForumAnswer::class, 'forum_answer_id');
     }
     
 }

--- a/backend/src/database/migrations/2026_03_16_190508_add_forum_answer_id_to_tickets_table.php
+++ b/backend/src/database/migrations/2026_03_16_190508_add_forum_answer_id_to_tickets_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->foreignId('forum_answer_id')
+                ->nullable()
+                ->constrained('forum_answers')
+                ->nullOnDelete()
+                ->after('code_connect_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('forum_answer_id');
+        });
+    }
+};

--- a/backend/src/tests/Feature/ReportingTickets/CreateTicketTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/CreateTicketTest.php
@@ -65,7 +65,7 @@ class CreateTicketTest extends TestCase
 
         $payload = [
             'code_connect_id' => $user->id,
-            'forum_answer_id' => 999999,
+            'forum_answer_id' => ForumAnswer::max('id') + 1,
             'name' => 'Reported forum answer',
             'incident_date' => now()->toDateString(),
             'affected_app' => 'code_connect',

--- a/backend/src/tests/Feature/ReportingTickets/CreateTicketTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/CreateTicketTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\ReportingTickets;
+
+use App\Models\ForumAnswer;
+use App\Models\ForumQuestion;
+use App\Models\ListProjects;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class CreateTicketTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_ticket_linked_to_a_forum_answer(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $project = ListProjects::factory()->create();
+        $questionUser = User::factory()->create();
+
+        $question = ForumQuestion::factory()->create([
+            'list_project_id' => $project->id,
+            'user_id' => $questionUser->id,
+        ]);
+
+        $forumAnswer = ForumAnswer::factory()->create([
+            'forum_question_id' => $question->id,
+            'user_id' => $questionUser->id,
+        ]);
+
+        $payload = [
+            'code_connect_id' => $user->id,
+            'forum_answer_id' => $forumAnswer->id,
+            'name' => 'Reported forum answer',
+            'incident_date' => now()->toDateString(),
+            'affected_app' => 'code_connect',
+            'type' => 'error',
+            'affected_function' => 'code_connect',
+            'description' => 'This answer should be reported',
+        ];
+
+        $response = $this->postJson('/api/tickets', $payload);
+
+        $response->assertCreated()
+            ->assertJson([
+                'success' => true,
+                'message' => 'The Ticket has been created correctly',
+            ]);
+
+        $this->assertDatabaseHas('tickets', [
+            'code_connect_id' => $user->id,
+            'forum_answer_id' => $forumAnswer->id,
+            'name' => 'Reported forum answer',
+        ]);
+    }
+
+    public function test_it_fails_if_forum_answer_id_does_not_exist(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $payload = [
+            'code_connect_id' => $user->id,
+            'forum_answer_id' => 999999,
+            'name' => 'Reported forum answer',
+            'incident_date' => now()->toDateString(),
+            'affected_app' => 'code_connect',
+            'type' => 'error',
+            'affected_function' => 'code_connect',
+            'description' => 'This answer should be reported',
+        ];
+
+        $response = $this->postJson('/api/tickets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['forum_answer_id']);
+    }
+}

--- a/backend/src/tests/Unit/TicketRequestValidationTest.php
+++ b/backend/src/tests/Unit/TicketRequestValidationTest.php
@@ -26,6 +26,7 @@ class TicketRequestValidationTest extends TestCase{
 
         $expectedRules = [
             'code_connect_id' => 'required|integer|exists:users,id',
+            'forum_answer_id' => 'nullable|integer|exists:forum_answers,id',
             'assignee_id' => 'nullable|integer|exists:users,id',
             'name' => 'required|string|max:255',
             'incident_date' => 'required|date',

--- a/backend/src/tests/Unit/TicketRequestsTest.php
+++ b/backend/src/tests/Unit/TicketRequestsTest.php
@@ -20,6 +20,7 @@ class TicketRequestsTest extends TestCase{
         //Determine the correct rules, here and the Request
         $this->assertEquals([
             'code_connect_id' => 'required|integer|exists:users,id',
+            'forum_answer_id' => 'nullable|integer|exists:forum_answers,id',
             'assignee_id' => 'nullable|integer|exists:users,id',
             'name' => 'required|string|max:255',
             'incident_date' => 'required|date',


### PR DESCRIPTION
## Summary
This PR adds the ability to create a ticket linked to a forum answer.

## Changes made
- added `forum_answer_id` to the `tickets` table
- updated the `Ticket` model to support the `forumAnswer` relation
- updated `CreateTicketRequest` validation to accept `forum_answer_id`
- added tests to verify ticket creation with a linked forum answer
- updated request validation tests accordingly

## Validation
- verified that a ticket can be created with a valid `forum_answer_id`
- verified that validation fails when `forum_answer_id` does not exist
- all tests are passing