### PR TITLE
Add ownership check for ticket show endpoint

### DIFF
--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -31,12 +31,11 @@ class TicketController extends Controller{
         ]);
     }
 
-    public function show($id): JsonResponse{
-
+    public function show($id): JsonResponse
+    {
         $ticket = Ticket::with(['codeConnect', 'assignee', 'closedBy', 'comments.user'])->findOrFail($id);
-        if ($ticket->code_connect_id !== auth()->id()) {
-        abort(403, 'Forbidden');
-        }
+        $this->ensureTicketOwnership($ticket);
+
         return response()->json([
             'success' => true,
             'data' => $ticket
@@ -58,9 +57,10 @@ class TicketController extends Controller{
         ], 201);
     }
 
-    public function update(UpdateTicketRequest $request, $id): JsonResponse{
-
+    public function update(UpdateTicketRequest $request, $id): JsonResponse
+    {
         $ticket = Ticket::findOrFail($id);
+        $this->ensureTicketOwnership($ticket);
 
         $ticket->update($request->validated());
 
@@ -71,9 +71,10 @@ class TicketController extends Controller{
         ], 200);
     }
 
-    public function destroy($id): JsonResponse{
-
+    public function destroy($id): JsonResponse
+    {
         $ticket = Ticket::findOrFail($id);
+        $this->ensureTicketOwnership($ticket);
 
         $ticket->delete();
 
@@ -83,12 +84,12 @@ class TicketController extends Controller{
         ], 200);
     }
 
-    public function updateStatus(UpdateStatusTicketRequest $request, $id): JsonResponse{
-
+    public function updateStatus(UpdateStatusTicketRequest $request, $id): JsonResponse
+    {
         $ticket = Ticket::findOrFail($id);
+        $this->ensureTicketOwnership($ticket);
 
         $status = $request->validated()['status'];
-
         $updateData = ['status' => $status];
 
         if ($status === 'closed') {
@@ -105,9 +106,10 @@ class TicketController extends Controller{
         ], 200);
     }
 
-    public function updatePriority(UpdatePriorityRequest $request, $id): JsonResponse{
-
+    public function updatePriority(UpdatePriorityRequest $request, $id): JsonResponse
+    {
         $ticket = Ticket::findOrFail($id);
+        $this->ensureTicketOwnership($ticket);
 
         $ticket->update(['priority' => $request->validated()['priority']]);
 
@@ -118,9 +120,10 @@ class TicketController extends Controller{
         ], 200);
     }
 
-    public function updateAssignee(AssignTicketRequest $request, $id): JsonResponse{
-
+    public function updateAssignee(AssignTicketRequest $request, $id): JsonResponse
+    {
         $ticket = Ticket::findOrFail($id);
+        $this->ensureTicketOwnership($ticket);
 
         $ticket->update(['assignee_id' => $request->validated()['assignee_id']]);
 
@@ -130,5 +133,11 @@ class TicketController extends Controller{
             'data' => $ticket->fresh(['codeConnect', 'assignee', 'closedBy'])
         ], 200);
     }
+
+    private function ensureTicketOwnership(Ticket $ticket): void
+    {
+        if ((int) $ticket->code_connect_id !== (int) auth()->id()) {
+            abort(403, 'Forbidden');
+        }
+    }
 }
-?>

--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -40,12 +40,15 @@ class TicketController extends Controller
 
     public function store(CreateTicketRequest $request): JsonResponse
     {
-        $ticket = Ticket::create($request->validated());
+        $data = $request->validated();
+        $data['code_connect_id'] = auth()->id();
+
+        $ticket = Ticket::create($data);
 
         return response()->json([
-            'success' => true,
-            'message' => 'The Ticket has been created correctly',
-            'data' => $ticket
+        'success' => true,
+        'message' => 'The Ticket has been created correctly',
+        'data' => $ticket
         ], 201);
     }
 

--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -34,7 +34,9 @@ class TicketController extends Controller{
     public function show($id): JsonResponse{
 
         $ticket = Ticket::with(['codeConnect', 'assignee', 'closedBy', 'comments.user'])->findOrFail($id);
-
+        if ($ticket->code_connect_id !== auth()->id()) {
+        abort(403, 'Forbidden');
+        }
         return response()->json([
             'success' => true,
             'data' => $ticket

--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -11,23 +11,19 @@ use App\Http\Requests\Tickets\UpdatePriorityRequest;
 use App\Http\Requests\Tickets\AssignTicketRequest;
 use Illuminate\Http\JsonResponse;
 
-class TicketController extends Controller{
-
-    public function index(): JsonResponse{
-
-        $user = auth()->user();
-
+class TicketController extends Controller
+{
+    public function index(): JsonResponse
+    {
         $query = Ticket::with(['codeConnect', 'assignee', 'closedBy']);
 
-        if (!$user->hasAnyRole(['admin', 'superadmin'])) {
-            $query->where('code_connect_id', $user->id);
+        if (! auth()->user()->hasAnyRole(['admin', 'superadmin'])) {
+            $query->where('code_connect_id', auth()->id());
         }
-
-        $tickets = $query->get();
 
         return response()->json([
             'success' => true,
-            'data' => $tickets
+            'data' => $query->get()
         ]);
     }
 
@@ -42,13 +38,9 @@ class TicketController extends Controller{
         ], 200);
     }
 
-    public function store(CreateTicketRequest $request): JsonResponse{
-
-        $ticket = Ticket::create([
-            ...$request->validated(),
-            'code_connect_id' => auth()->id(),
-        ]);
-
+    public function store(CreateTicketRequest $request): JsonResponse
+    {
+        $ticket = Ticket::create($request->validated());
 
         return response()->json([
             'success' => true,
@@ -136,6 +128,10 @@ class TicketController extends Controller{
 
     private function ensureTicketOwnership(Ticket $ticket): void
     {
+        if (auth()->user()->hasAnyRole(['admin', 'superadmin'])) {
+            return;
+        }
+
         if ((int) $ticket->code_connect_id !== (int) auth()->id()) {
             abort(403, 'Forbidden');
         }

--- a/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
@@ -117,56 +117,51 @@ class TicketControllerTest extends TestCase{
         $response->assertStatus(401);
     }
 
-    /** @test */
-    public function an_auth_user_can_update_a_ticket(): void{
-
+   /** @test */
+    public function an_auth_user_can_update_their_own_ticket(): void{
         $user = User::factory()->create();
         Sanctum::actingAs($user);
 
         $ticket = Ticket::factory()->create([
-
-            'name' => 'Old Name',
-            'affected_app' => 'wiki_frontend',
-            'type' => 'error',
-            'affected_function' => 'login',
-            'description' => 'Old description.',
+         'code_connect_id' => $user->id,
+         'name' => 'Old Name',
+         'affected_app' => 'wiki_frontend',
+         'type' => 'error',
+         'affected_function' => 'login',
+         'description' => 'Old description.',
         ]);
-        
 
-
-        $response = $this->actingAs($user)->putJson("/api/tickets/{$ticket->id}", [
-            'name' => 'Updated Name',
-            'affected_app' => 'wiki_backend',
-            'type' => 'suggestion',
-            'affected_function' => 'profile',
-            'description' => 'Updated description.',
+        $response = $this->putJson("/api/tickets/{$ticket->id}", [
+         'name' => 'Updated Name',
+         'affected_app' => 'wiki_backend',
+         'type' => 'suggestion',
+         'affected_function' => 'profile',
+         'description' => 'Updated description.',
         ]);
-        
+
         $response->assertStatus(200)->assertJsonStructure([
-            'data' => [
-                'id',
-                'name',
-                'affected_app',
-                'type',
-                'affected_function',
-                'description',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
-        
+        'data' => [
+            'id',
+            'name',
+            'affected_app',
+            'type',
+            'affected_function',
+            'description',
+            'created_at',
+            'updated_at'
+        ]
+    ]);
 
-        $this->assertDatabaseHas('tickets', [
-            'id' => $ticket->id,
-            'name' => 'Updated Name',
-            'affected_app' => 'wiki_backend',
-            'type' => 'suggestion',
-            'affected_function' => 'profile',
-            'description' => 'Updated description.',
-        ]);
-        
-    }
-
+    $this->assertDatabaseHas('tickets', [
+        'id' => $ticket->id,
+        'code_connect_id' => $user->id,
+        'name' => 'Updated Name',
+        'affected_app' => 'wiki_backend',
+        'type' => 'suggestion',
+        'affected_function' => 'profile',
+        'description' => 'Updated description.',
+    ]);
+}
     /** @test*/
     public function an_not_auth_user_cannot_update_a_ticket(): void{
 
@@ -183,20 +178,22 @@ class TicketControllerTest extends TestCase{
         $response->assertStatus(401);
     }
 
-    /** @test */
-    public function an_auth_user_can_delete_a_ticket(): void{
 
+   /** @test */
+    public function an_auth_user_can_delete_their_own_ticket(): void{
         $user = User::factory()->create();
         Sanctum::actingAs($user);
 
-        $ticket = Ticket::factory()->create();
+        $ticket = Ticket::factory()->create([
+         'code_connect_id' => $user->id,
+       ]);
 
         $response = $this->deleteJson("/api/tickets/{$ticket->id}");
 
         $response->assertStatus(200);
 
         $this->assertDatabaseMissing('tickets', [
-            'id' => $ticket->id,
+         'id' => $ticket->id,
         ]);
     }
 

--- a/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
@@ -67,13 +67,13 @@ class TicketControllerTest extends TestCase{
     }
 
     /** @test */
-    public function an_auth_user_can_view_a_ticket(): void{
-
+    public function an_auth_user_can_view_their_own_ticket(): void{
         $user = User::factory()->create();
         Sanctum::actingAs($user);
 
-        $ticket = Ticket::factory()->create();
-
+        $ticket = Ticket::factory()->create([
+         'code_connect_id' => $user->id,
+        ]);
 
         $response = $this->getJson("/api/tickets/{$ticket->id}");
 
@@ -89,7 +89,22 @@ class TicketControllerTest extends TestCase{
                 'updated_at'
             ]
         ]);
-        
+    }
+
+    /** @test */
+    public function an_auth_user_cannot_view_another_users_ticket(): void{
+        $user = User::factory()->create();
+        $owner = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $ticket = Ticket::factory()->create([
+         'code_connect_id' => $owner->id,
+        ]);
+
+        $response = $this->getJson("/api/tickets/{$ticket->id}");
+
+        $response->assertStatus(403);
     }
 
     /** @test */

--- a/backend/src/tests/Feature/TicketBusinessLogicTest.php
+++ b/backend/src/tests/Feature/TicketBusinessLogicTest.php
@@ -153,18 +153,19 @@ class TicketBusinessLogicTest extends TestCase{
 
     /** @test */
     public function closing_ticket_sets_closed_by_automatically(): void{
-
-        $creator = User::factory()->create();
+    
         $closer = User::factory()->create();
         Sanctum::actingAs($closer);
 
         $ticket = Ticket::factory()->create([
-            'code_connect_id' => $creator->id,
-            'closed_by' => null,
-            'closed_at' => null,
+          'code_connect_id' => $closer->id,
+          'closed_by' => null,
+          'closed_at' => null,
         ]);
 
-        $this->patchJson("/api/tickets/{$ticket->id}/status", ['status' => 'closed']);
+        $response = $this->patchJson("/api/tickets/{$ticket->id}/status", ['status' => 'closed']);
+
+        $response->assertStatus(200);
 
         $ticket->refresh();
         $this->assertEquals($closer->id, $ticket->closed_by);


### PR DESCRIPTION
## What
Adds ownership validation to ticket endpoints.

## Why
Prevents authenticated users from accessing or modifying tickets that do not belong to them.

## Changes
- Added ownership validation for ticket access and management
- Cast ownership comparison to avoid type mismatch issues
- Updated feature/business tests to reflect ownership rules
- Returns `403 Forbidden` when the ticket does not belong to the authenticated user

## Manual testing
- Created ticket `23` with `code_connect_id = 2`
- User `1` requesting ticket `23` -> `403 Forbidden`
- User `2` requesting ticket `23` -> `200 OK`

## Tests
- Updated tests so owner operations return `200 OK`
- Added/adjusted authorization behavior to reflect ownership restrictions
- Full test suite passing