### PR TITLE
test: add user_id visibility test for contributor listing

### DIFF
--- a/backend/src/tests/Feature/ContributorTests/ContributorsCrudTest.php
+++ b/backend/src/tests/Feature/ContributorTests/ContributorsCrudTest.php
@@ -328,4 +328,26 @@ class ContributorsCrudTest extends TestCase
             'id' => $contributor->id,
         ]);
     }
+
+    public function test_contributor_is_listed_with_correct_user_id(): void
+    {
+        ContributorListProject::factory()->create([
+            'user_id' => $this->user->id,
+            'list_project_id' => $this->project->id,
+            'status' => ContributorStatusEnum::Accepted->value,
+        ]);
+
+        $response = $this->getJson("/api/codeconnect/{$this->project->id}/contributors");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data' => [
+                    [
+                        'user_id' => $this->user->id,
+                    ],
+                ],
+            ]);
+    }
+
 }


### PR DESCRIPTION
Adds a test to verify that when listing contributors of a project, the API response correctly exposes the user_id field for each contributor, addressing the gap noted in the review of PR #172.
