### PR TITLE
style: update ProjectCard and skeleton layout for CodeConnect items list

### DIFF
--- a/frontend/src/components/code-connect/CodeConnectCardSkeleton.tsx
+++ b/frontend/src/components/code-connect/CodeConnectCardSkeleton.tsx
@@ -6,31 +6,30 @@ const CodeConnectCardSkeleton = () => {
     >
       <div className="w-full">
         <div className="h-6 w-3/4 bg-gray-300 rounded" />
-        <div className="h-4 w-24 bg-gray-300 rounded mt-2" />
       </div>
 
-      <div className="flex w-full gap-4 mt-5">
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-14 bg-gray-300 rounded" />
-          <div className="w-7 h-7 bg-gray-300 rounded" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-14 bg-gray-300 rounded" />
-          <div className="w-7 h-7 bg-gray-300 rounded" />
-        </div>
-      </div>
+      <div className="w-full mt-6">
+        <div className="h-6 w-16 bg-gray-300 rounded mb-4" />
 
-      <div className="flex w-full gap-2 mt-4">
-        <div className="w-full grid grid-cols-2 gap-4 grid-rows-2 border-r-2 pr-2 border-gray-200">
-          {[...Array(4)].map((_, i) => (
+        <div className="flex w-full items-center gap-4 mb-4">
+          <div className="h-4 w-16 bg-gray-300 rounded" />
+          <div className="w-7 h-7 bg-gray-300 rounded" />
+        </div>
+        <div className="w-full grid grid-cols-3 gap-2 justify-items-start mb-4">
+          {[...Array(3)].map((_, i) => (
             <div key={i} className="flex flex-col items-center">
               <div className="w-12 h-12 bg-gray-300 rounded-full" />
               <div className="h-3 w-10 bg-gray-300 rounded mt-1" />
             </div>
           ))}
         </div>
-        <div className="w-full grid grid-cols-2 gap-4 grid-rows-2 pl-1">
-          {[...Array(4)].map((_, i) => (
+
+        <div className="flex w-full items-center gap-4 mb-4">
+          <div className="h-4 w-16 bg-gray-300 rounded" />
+          <div className="w-7 h-7 bg-gray-300 rounded" />
+        </div>
+        <div className="w-full grid grid-cols-3 gap-2 justify-items-start">
+          {[...Array(3)].map((_, i) => (
             <div key={i} className="flex flex-col items-center">
               <div className="w-12 h-12 bg-gray-300 rounded-full" />
               <div className="h-3 w-10 bg-gray-300 rounded mt-1" />
@@ -40,15 +39,21 @@ const CodeConnectCardSkeleton = () => {
       </div>
 
       <div className="w-full mt-10">
-        <div className="h-4 w-20 bg-gray-300 rounded mb-2" />
-      </div>
-
-      <div className="w-full max-w-md mt-2">
+        <div className="h-6 w-40 bg-gray-300 rounded mb-4" />
         <div className="flex justify-between mb-1">
           <div className="h-3 w-14 bg-gray-300 rounded" />
           <div className="h-3 w-14 bg-gray-300 rounded" />
         </div>
         <div className="h-2 w-full bg-gray-300 rounded-full" />
+      </div>
+
+      <div className="w-full mt-10">
+        <div className="h-6 w-20 bg-gray-300 rounded mb-4" />
+        <div className="h-4 w-32 bg-gray-300 rounded" />
+      </div>
+
+      <div className="w-full">
+        <div className="my-5 w-full h-10 bg-gray-300 rounded-lg" />
       </div>
     </div>
   );

--- a/frontend/src/components/code-connect/projectCard/ProjectCard.tsx
+++ b/frontend/src/components/code-connect/projectCard/ProjectCard.tsx
@@ -34,14 +34,24 @@ function ProjectCard({ project }: ProjectCardProps) {
 
         <div className="flex w-full items-center gap-4 mb-4">
           <h3 className="text-sm font-bold">Frontend</h3>
-          <img className="w-7" src={resolveAsset(project.frontend.logo)} alt={project.frontend.tech} />
+          <img
+            className="w-7"
+            src={resolveAsset(project.frontend.logo)}
+            alt={project.frontend.tech}
+          />
         </div>
         <div className="flex w-full gap-2 mb-4">
           <div className="w-full grid grid-cols-3 gap-2 justify-items-start">
             {project.frontend.participants.map((p, i) => (
               <figure className="flex flex-col items-center" key={i}>
-                <img className="w-12 h-12" src={resolveAsset(p.avatar)} alt={p.name} />
-                <figcaption className="text-xs mt-1 font-bold text-gray-500">{p.name}</figcaption>
+                <img
+                  className="w-12 h-12"
+                  src={resolveAsset(p.avatar)}
+                  alt={p.name}
+                />
+                <figcaption className="text-xs mt-1 font-bold text-gray-500">
+                  {p.name}
+                </figcaption>
               </figure>
             ))}
             {[...Array(availableFrontend)].map((_, i) => {
@@ -50,16 +60,39 @@ function ProjectCard({ project }: ProjectCardProps) {
               const accepted = slots.isAccepted("frontend", index);
               if (pending) {
                 return (
-                  <figure key={`front-pending-${index}`} className="flex flex-col items-center" onClick={() => decisionModal.open("frontend", index)}>
-                    <div className={`w-12 h-12 rounded-full border-2 cursor-pointer overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}>
-                      <img className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`} src={userAvatar} alt="Pending contributor" />
+                  <figure
+                    key={`front-pending-${index}`}
+                    className="flex flex-col items-center"
+                    onClick={() => decisionModal.open("frontend", index)}
+                  >
+                    <div
+                      className={`w-12 h-12 rounded-full border-2 cursor-pointer overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}
+                    >
+                      <img
+                        className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`}
+                        src={userAvatar}
+                        alt="Pending contributor"
+                      />
                     </div>
-                    <figcaption className="text-xs mt-1 font-bold text-gray-500">{accepted ? "Contributor" : "Pending"}</figcaption>
+                    <figcaption className="text-xs mt-1 font-bold text-gray-500">
+                      {accepted ? "Contributor" : "Pending"}
+                    </figcaption>
                   </figure>
                 );
               }
               return (
-                <ProjectButton key={`front-${index}`} onClick={() => joinModal.open({ area: "frontend", index, role: "Frontend Developer" })}>+</ProjectButton>
+                <ProjectButton
+                  key={`front-${index}`}
+                  onClick={() =>
+                    joinModal.open({
+                      area: "frontend",
+                      index,
+                      role: "Frontend Developer",
+                    })
+                  }
+                >
+                  +
+                </ProjectButton>
               );
             })}
           </div>
@@ -67,14 +100,24 @@ function ProjectCard({ project }: ProjectCardProps) {
 
         <div className="flex w-full items-center gap-4 mb-4">
           <h3 className="text-sm font-bold">Backend</h3>
-          <img className="w-7" src={resolveAsset(project.backend.logo)} alt={project.backend.tech} />
+          <img
+            className="w-7"
+            src={resolveAsset(project.backend.logo)}
+            alt={project.backend.tech}
+          />
         </div>
         <div className="flex w-full gap-2">
           <div className="w-full grid grid-cols-3 gap-2 justify-items-start">
             {project.backend.participants.map((p, i) => (
               <figure className="flex flex-col items-center" key={i}>
-                <img className="w-12 h-12" src={resolveAsset(p.avatar)} alt={p.name} />
-                <figcaption className="text-xs mt-1 font-bold text-gray-500">{p.name}</figcaption>
+                <img
+                  className="w-12 h-12"
+                  src={resolveAsset(p.avatar)}
+                  alt={p.name}
+                />
+                <figcaption className="text-xs mt-1 font-bold text-gray-500">
+                  {p.name}
+                </figcaption>
               </figure>
             ))}
             {[...Array(availableBackend)].map((_, i) => {
@@ -83,16 +126,39 @@ function ProjectCard({ project }: ProjectCardProps) {
               const accepted = slots.isAccepted("backend", index);
               if (pending) {
                 return (
-                  <figure key={`back-pending-${index}`} className="flex flex-col items-center" onClick={() => decisionModal.open("backend", index)}>
-                    <div className={`w-12 h-12 rounded-full cursor-pointer border-2 overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}>
-                      <img className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`} src={userAvatar} alt="Pending contributor" />
+                  <figure
+                    key={`back-pending-${index}`}
+                    className="flex flex-col items-center"
+                    onClick={() => decisionModal.open("backend", index)}
+                  >
+                    <div
+                      className={`w-12 h-12 rounded-full cursor-pointer border-2 overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}
+                    >
+                      <img
+                        className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`}
+                        src={userAvatar}
+                        alt="Pending contributor"
+                      />
                     </div>
-                    <figcaption className="text-xs mt-1 font-bold text-gray-500">{accepted ? "Contributor" : "Pending"}</figcaption>
+                    <figcaption className="text-xs mt-1 font-bold text-gray-500">
+                      {accepted ? "Contributor" : "Pending"}
+                    </figcaption>
                   </figure>
                 );
               }
               return (
-                <ProjectButton key={`back-${index}`} onClick={() => joinModal.open({ area: "backend", index, role: "Backend Developer" })}>+</ProjectButton>
+                <ProjectButton
+                  key={`back-${index}`}
+                  onClick={() =>
+                    joinModal.open({
+                      area: "backend",
+                      index,
+                      role: "Backend Developer",
+                    })
+                  }
+                >
+                  +
+                </ProjectButton>
               );
             })}
           </div>
@@ -100,13 +166,21 @@ function ProjectCard({ project }: ProjectCardProps) {
       </div>
 
       <div className="w-full mt-10">
-        <h2 className="font-extrabold text-xl text-start mb-4">Termini d'inscripció</h2>
-        <ProgressBar title="Progrés del projecte" startDate={project.startDate} endDate={project.endDate} />
+        <h2 className="font-extrabold text-xl text-start mb-4">
+          Termini d'inscripció
+        </h2>
+        <ProgressBar
+          title="Progrés del projecte"
+          startDate={project.startDate}
+          endDate={project.endDate}
+        />
       </div>
 
       <div className="w-full mt-10">
         <h2 className="font-extrabold text-xl text-start mb-4">Durada</h2>
-        <p className="text-sm font-bold text-start">{project.duration || "No especificada"}</p>
+        <p className="text-sm font-bold text-start">
+          {project.duration || "No especificada"}
+        </p>
       </div>
 
       <div className="w-full">
@@ -121,12 +195,17 @@ function ProjectCard({ project }: ProjectCardProps) {
         title="Unir-te al projecte"
         showPrimaryButton
         primaryButtonText={joinModal.isSubmitting ? "Enviant..." : "Confirmar"}
-        primaryButtonAction={joinModal.isSubmitting ? undefined : joinModal.confirm}
+        primaryButtonAction={
+          joinModal.isSubmitting ? undefined : joinModal.confirm
+        }
         showSecondaryButton
         secondaryButtonText="Cancel·lar"
         secondaryButtonAction={joinModal.close}
       >
-        <p>Vols unir-te com a {joinModal.selectedSlot?.role ?? "participant"} al projecte "{project.title}"?</p>
+        <p>
+          Vols unir-te com a {joinModal.selectedSlot?.role ?? "participant"} al
+          projecte "{project.title}"?
+        </p>
       </GenericModal>
       <GenericModal
         isOpen={decisionModal.isOpen}
@@ -139,7 +218,10 @@ function ProjectCard({ project }: ProjectCardProps) {
         secondaryButtonText="Rebutjar"
         secondaryButtonAction={decisionModal.reject}
       >
-        <p>Vols acceptar o rebutjar aquest contribuidor pendent al projecte "{project.title}"?</p>
+        <p>
+          Vols acceptar o rebutjar aquest contribuidor pendent al projecte "
+          {project.title}"?
+        </p>
       </GenericModal>
     </article>
   );

--- a/frontend/src/components/code-connect/projectCard/ProjectCard.tsx
+++ b/frontend/src/components/code-connect/projectCard/ProjectCard.tsx
@@ -18,177 +18,115 @@ function ProjectCard({ project }: ProjectCardProps) {
     project.frontend.positions - project.frontend.participants.length;
   const availableBackend =
     project.backend.positions - project.backend.participants.length;
+
   return (
-    <div className="flex flex-col border scale-95 sm:scale-none border-gray-500 text-black items-center w-70 sm:w-76 xl:w-82 px-6 rounded-3xl py-7 pb-10">
+    <article className="flex flex-col border scale-95 sm:scale-none border-gray-500 text-black items-center w-70 sm:w-76 xl:w-82 px-6 rounded-3xl py-7 pb-10">
       <div className="w-full">
         <Link to={`/codeconnect/${project.id}`}>
-          <h1 className="font-extrabold text-black w-fit hover:text-primary transition-colors duration-300 text-xl text-start">
+          <h2 className="font-extrabold text-black w-fit hover:text-primary transition-colors duration-300 text-xl text-start">
             {project.title}
-          </h1>
+          </h2>
         </Link>
-        <p className="text-sm font-bold text-gray-500 text-start">
-          Durada: {project.duration}
-        </p>
       </div>
-      <div className="flex w-full gap-4 mt-5">
-        <div className="flex w-full items-center gap-3 sm:gap-4 xl:gap-6">
-          <h2 className="text-sm font-bold">Frontend</h2>
-          <img
-            className="w-7"
-            src={resolveAsset(project.frontend.logo)}
-            alt={project.frontend.tech}
-          />
-        </div>
-        <div className="flex w-full items-center gap-3 sm:gap-5 xl:gap-7">
-          <h2 className="text-sm font-bold">Backend</h2>
-          <img
-            className="w-7"
-            src={resolveAsset(project.backend.logo)}
-            alt={project.backend.tech}
-          />
-        </div>
-      </div>
-      <div className="flex w-full gap-2 mt-4">
-        <div className="w-full grid grid-cols-2 gap-4 grid-rows-2 border-r-2 pr-2 border-gray-200">
-          {project.frontend.participants.map((p, i) => (
-            <figure className="flex flex-col items-center" key={i}>
-              <img
-                className="w-12 h-12"
-                src={resolveAsset(p.avatar)}
-                alt={p.name}
-              />
-              <figcaption className="text-xs mt-1 font-bold text-gray-500">
-                {p.name}
-              </figcaption>
-            </figure>
-          ))}
-          {[...Array(availableFrontend)].map((_, i) => {
-            const index = project.frontend.participants.length + i;
-            const pending = slots.isPending("frontend", index);
-            const accepted = slots.isAccepted("frontend", index);
 
-            if (pending) {
+      <div className="w-full mt-6">
+        <h2 className="font-extrabold text-xl text-start mb-4">Equip</h2>
+
+        <div className="flex w-full items-center gap-4 mb-4">
+          <h3 className="text-sm font-bold">Frontend</h3>
+          <img className="w-7" src={resolveAsset(project.frontend.logo)} alt={project.frontend.tech} />
+        </div>
+        <div className="flex w-full gap-2 mb-4">
+          <div className="w-full grid grid-cols-3 gap-2 justify-items-start">
+            {project.frontend.participants.map((p, i) => (
+              <figure className="flex flex-col items-center" key={i}>
+                <img className="w-12 h-12" src={resolveAsset(p.avatar)} alt={p.name} />
+                <figcaption className="text-xs mt-1 font-bold text-gray-500">{p.name}</figcaption>
+              </figure>
+            ))}
+            {[...Array(availableFrontend)].map((_, i) => {
+              const index = project.frontend.participants.length + i;
+              const pending = slots.isPending("frontend", index);
+              const accepted = slots.isAccepted("frontend", index);
+              if (pending) {
+                return (
+                  <figure key={`front-pending-${index}`} className="flex flex-col items-center" onClick={() => decisionModal.open("frontend", index)}>
+                    <div className={`w-12 h-12 rounded-full border-2 cursor-pointer overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}>
+                      <img className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`} src={userAvatar} alt="Pending contributor" />
+                    </div>
+                    <figcaption className="text-xs mt-1 font-bold text-gray-500">{accepted ? "Contributor" : "Pending"}</figcaption>
+                  </figure>
+                );
+              }
               return (
-                <figure
-                  key={`front-pending-${index}`}
-                  className="flex flex-col items-center"
-                  onClick={() => decisionModal.open("frontend", index)}
-                >
-                  <div
-                    className={`w-12 h-12 rounded-full border-2 cursor-pointer overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}
-                  >
-                    <img
-                      className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`}
-                      src={userAvatar}
-                      alt="Pending contributor"
-                    />
-                  </div>
-                  <figcaption className="text-xs mt-1 font-bold text-gray-500">
-                    {accepted ? "Contributor" : "Pending"}
-                  </figcaption>
-                </figure>
+                <ProjectButton key={`front-${index}`} onClick={() => joinModal.open({ area: "frontend", index, role: "Frontend Developer" })}>+</ProjectButton>
               );
-            }
-
-            return (
-              <ProjectButton
-                key={`front-${index}`}
-                onClick={() =>
-                  joinModal.open({
-                    area: "frontend",
-                    index,
-                    role: "Frontend Developer",
-                  })
-                }
-              >
-                +
-              </ProjectButton>
-            );
-          })}
+            })}
+          </div>
         </div>
-        <div className="w-full grid grid-cols-2 justify-items-center grid-rows-2 pl-1 gap-4">
-          {project.backend.participants.map((p, i) => (
-            <figure className="flex flex-col items-center" key={i}>
-              <img
-                className="w-12 h-12"
-                src={resolveAsset(p.avatar)}
-                alt={p.name}
-              />
-              <figcaption className="text-xs mt-1 font-bold text-gray-500">
-                {p.name}
-              </figcaption>
-            </figure>
-          ))}
-          {[...Array(availableBackend)].map((_, i) => {
-            const index = project.backend.participants.length + i;
-            const pending = slots.isPending("backend", index);
-            const accepted = slots.isAccepted("backend", index);
 
-            if (pending) {
+        <div className="flex w-full items-center gap-4 mb-4">
+          <h3 className="text-sm font-bold">Backend</h3>
+          <img className="w-7" src={resolveAsset(project.backend.logo)} alt={project.backend.tech} />
+        </div>
+        <div className="flex w-full gap-2">
+          <div className="w-full grid grid-cols-3 gap-2 justify-items-start">
+            {project.backend.participants.map((p, i) => (
+              <figure className="flex flex-col items-center" key={i}>
+                <img className="w-12 h-12" src={resolveAsset(p.avatar)} alt={p.name} />
+                <figcaption className="text-xs mt-1 font-bold text-gray-500">{p.name}</figcaption>
+              </figure>
+            ))}
+            {[...Array(availableBackend)].map((_, i) => {
+              const index = project.backend.participants.length + i;
+              const pending = slots.isPending("backend", index);
+              const accepted = slots.isAccepted("backend", index);
+              if (pending) {
+                return (
+                  <figure key={`back-pending-${index}`} className="flex flex-col items-center" onClick={() => decisionModal.open("backend", index)}>
+                    <div className={`w-12 h-12 rounded-full cursor-pointer border-2 overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}>
+                      <img className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`} src={userAvatar} alt="Pending contributor" />
+                    </div>
+                    <figcaption className="text-xs mt-1 font-bold text-gray-500">{accepted ? "Contributor" : "Pending"}</figcaption>
+                  </figure>
+                );
+              }
               return (
-                <figure
-                  key={`back-pending-${index}`}
-                  className="flex flex-col items-center"
-                  onClick={() => decisionModal.open("backend", index)}
-                >
-                  <div
-                    className={`w-12 h-12 rounded-full cursor-pointer border-2 overflow-hidden flex items-center justify-center ${accepted ? "border-transparent" : "border-orange-500"}`}
-                  >
-                    <img
-                      className={`w-full h-full object-cover ${accepted ? "" : "grayscale"}`}
-                      src={userAvatar}
-                      alt="Pending contributor"
-                    />
-                  </div>
-                  <figcaption className="text-xs mt-1 font-bold text-gray-500">
-                    {accepted ? "Contributor" : "Pending"}
-                  </figcaption>
-                </figure>
+                <ProjectButton key={`back-${index}`} onClick={() => joinModal.open({ area: "backend", index, role: "Backend Developer" })}>+</ProjectButton>
               );
-            }
-
-            return (
-              <ProjectButton
-                key={`back-${index}`}
-                onClick={() =>
-                  joinModal.open({
-                    area: "backend",
-                    index,
-                    role: "Backend Developer",
-                  })
-                }
-              >
-                +
-              </ProjectButton>
-            );
-          })}
+            })}
+          </div>
         </div>
       </div>
+
+      <div className="w-full mt-10">
+        <h2 className="font-extrabold text-xl text-start mb-4">Termini d'inscripció</h2>
+        <ProgressBar title="Progrés del projecte" startDate={project.startDate} endDate={project.endDate} />
+      </div>
+
+      <div className="w-full mt-10">
+        <h2 className="font-extrabold text-xl text-start mb-4">Durada</h2>
+        <p className="text-sm font-bold text-start">{project.duration || "No especificada"}</p>
+      </div>
+
       <div className="w-full">
-        <h2 className="text-sm mt-10 font-bold text-start mb-2">Inscripció</h2>
-        <ProgressBar
-          title="Progrés del projecte"
-          startDate={project.startDate}
-          endDate={project.endDate}
-        />
+        <button className="my-5 w-full bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary/90 transition cursor-pointer font-bold">
+          Apuntar-me
+        </button>
       </div>
+
       <GenericModal
         isOpen={joinModal.isOpen}
         onClose={joinModal.close}
         title="Unir-te al projecte"
         showPrimaryButton
         primaryButtonText={joinModal.isSubmitting ? "Enviant..." : "Confirmar"}
-        primaryButtonAction={
-          joinModal.isSubmitting ? undefined : joinModal.confirm
-        }
+        primaryButtonAction={joinModal.isSubmitting ? undefined : joinModal.confirm}
         showSecondaryButton
         secondaryButtonText="Cancel·lar"
         secondaryButtonAction={joinModal.close}
       >
-        <p>
-          Vols unir-te com a {joinModal.selectedSlot?.role ?? "participant"} al
-          projecte "{project.title}"?
-        </p>
+        <p>Vols unir-te com a {joinModal.selectedSlot?.role ?? "participant"} al projecte "{project.title}"?</p>
       </GenericModal>
       <GenericModal
         isOpen={decisionModal.isOpen}
@@ -201,12 +139,9 @@ function ProjectCard({ project }: ProjectCardProps) {
         secondaryButtonText="Rebutjar"
         secondaryButtonAction={decisionModal.reject}
       >
-        <p>
-          Vols acceptar o rebutjar aquest contribuidor pendent al projecte "
-          {project.title}"?
-        </p>
+        <p>Vols acceptar o rebutjar aquest contribuidor pendent al projecte "{project.title}"?</p>
       </GenericModal>
-    </div>
+    </article>
   );
 }
 

--- a/frontend/src/components/code-connect/projectCard/__test__/ProjectCard.test.tsx
+++ b/frontend/src/components/code-connect/projectCard/__test__/ProjectCard.test.tsx
@@ -44,12 +44,11 @@ describe("ProjectCard", () => {
     render(<ProjectCard project={project} />, { wrapper });
 
     expect(screen.getByText(project.title)).toBeInTheDocument();
-    expect(
-      screen.getByText((t) => t.includes(`Durada: ${project.duration}`)),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Durada")).toBeInTheDocument();
+    expect(screen.getByText(project.duration!)).toBeInTheDocument();
     expect(screen.getByText("Frontend")).toBeInTheDocument();
     expect(screen.getByText("Backend")).toBeInTheDocument();
-    expect(screen.getByText("Inscripció")).toBeInTheDocument();
+    expect(screen.getByText("Termini d'inscripció")).toBeInTheDocument();
   });
 
   it("renders logos and participant avatars with correct alt text", () => {

--- a/frontend/src/moock/projects.json
+++ b/frontend/src/moock/projects.json
@@ -15,7 +15,7 @@
     "backend": {
       "tech": "Java",
       "logo": "../assets/logo-java-1.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": []
     },
     "startDate": "10-01-2025",
@@ -37,7 +37,7 @@
     "backend": {
       "tech": "PHP",
       "logo": "../assets/logo-php-1.svg",
-      "positions": 4,
+      "positions": 3,
       "participants": [
         { "name": "Roman", "avatar": "../assets/project-avatar3.jpg" }
       ]
@@ -52,7 +52,7 @@
     "frontend": {
       "tech": "Angular",
       "logo": "../assets/angular.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": [
         { "name": "Natasha", "avatar": "../assets/project-avatar.jpg" },
         { "name": "Aina", "avatar": "../assets/project-avatar4.jpg" }
@@ -61,7 +61,7 @@
     "backend": {
       "tech": "Java",
       "logo": "../assets/logo-java-1.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": []
     },
     "startDate": "10-20-2025",
@@ -74,7 +74,7 @@
     "frontend": {
       "tech": "Angular",
       "logo": "../assets/angular.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": [
         { "name": "Natasha", "avatar": "../assets/project-avatar.jpg" },
         { "name": "Jordi", "avatar": "../assets/project-avatar2.jpg" }
@@ -83,7 +83,7 @@
     "backend": {
       "tech": "Java",
       "logo": "../assets/logo-java-1.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": []
     },
     "startDate": "10-25-2025",
@@ -105,7 +105,7 @@
     "backend": {
       "tech": "PHP",
       "logo": "../assets/logo-php-1.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": [
         { "name": "Roman", "avatar": "../assets/project-avatar3.jpg" }
       ]
@@ -120,7 +120,7 @@
     "frontend": {
       "tech": "Angular",
       "logo": "../assets/angular.svg",
-      "positions": 2,
+      "positions": 3,
       "participants": [
         { "name": "Natasha", "avatar": "../assets/project-avatar.jpg" },
         { "name": "Aina", "avatar": "../assets/project-avatar4.jpg" }
@@ -129,7 +129,7 @@
     "backend": {
       "tech": "Java",
       "logo": "../assets/logo-java-1.svg",
-      "positions": 4,
+      "positions": 3,
       "participants": [
         { "name": "Roman", "avatar": "../assets/project-avatar3.jpg" }
       ]
@@ -144,7 +144,7 @@
     "frontend": {
       "tech": "React",
       "logo": "../assets/react.svg",
-      "positions": 4,
+      "positions": 3,
       "participants": [
         { "name": "Natasha", "avatar": "../assets/project-avatar.jpg" },
         { "name": "Jordi", "avatar": "../assets/project-avatar2.jpg" }
@@ -153,7 +153,7 @@
     "backend": {
       "tech": "PHP",
       "logo": "../assets/logo-php-1.svg",
-      "positions": 4,
+      "positions": 3,
       "participants": [
         { "name": "Roman", "avatar": "../assets/project-avatar3.jpg" },
         { "name": "Aina", "avatar": "../assets/project-avatar4.jpg" }
@@ -193,7 +193,7 @@
     "frontend": {
       "tech": "React",
       "logo": "../assets/react.svg",
-      "positions": 4,
+      "positions": 3,
       "participants": [
         { "name": "Aina", "avatar": "../assets/project-avatar4.jpg" },
         { "name": "Jordi", "avatar": "../assets/project-avatar2.jpg" }
@@ -202,7 +202,7 @@
     "backend": {
       "tech": "PHP",
       "logo": "../assets/logo-php-1.svg",
-      "positions": 4,
+      "positions": 3,
       "participants": [
         { "name": "Roman", "avatar": "../assets/project-avatar3.jpg" },
         { "name": "Natasha", "avatar": "../assets/project-avatar.jpg" }


### PR DESCRIPTION
### PR Description
- Set avatar grids to 3 columns (frontend & backend), left-aligned
- Set all mock project positions to 3 for frontend and backend
- Rewrite CodeConnectCardSkeleton to match new card structure
- Remove JSX comments from skeleton
- Fix ProjectCard tests: update text assertions to match new headings ("Durada" + duration separately, "Termini d'inscripció" instead of "Inscripció")

Before:
<img width="1236" height="779" alt="image" src="https://github.com/user-attachments/assets/d3740b2e-4d37-4f90-82bd-4988ab0e9398" />

After:
<img width="1236" height="779" alt="image" src="https://github.com/user-attachments/assets/b8ffb44b-2452-42aa-8b04-f310c6f949de" />

