### PR TITLE
Issue 326 - Included auth token in the create code connect project function

### DIFF
--- a/frontend/src/api/endPointCodeConnect.test.ts
+++ b/frontend/src/api/endPointCodeConnect.test.ts
@@ -60,9 +60,11 @@ describe("createCodeConnect", () => {
       "https://localhost:8000/codeconnect/create",
       expect.objectContaining({
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: expect.stringContaining("Bearer "),
+        }),
         body: JSON.stringify(mockNewCodeConnect),
-        signal: undefined,
       }),
     );
 
@@ -89,6 +91,16 @@ describe("createCodeConnect", () => {
     } as CodeConnectError);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw an error with ABORTED code when the request is aborted", async () => {
+    const abortError = new DOMException("Aborted", "AbortError");
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    await expect(createCodeConnect(mockNewCodeConnect)).rejects.toMatchObject({
+      message: "Petició cancel·lada",
+      code: "ABORTED",
+    } as CodeConnectError);
   });
 
   it("should throw an error on network failure", async () => {

--- a/frontend/src/api/endPointCodeConnect.ts
+++ b/frontend/src/api/endPointCodeConnect.ts
@@ -13,12 +13,14 @@ export const createCodeConnect = async (
   signal?: AbortSignal,
 ) => {
   const url = `${API_URL}${END_POINTS.codeconnect.post}`;
-
+  const token = localStorage.getItem("auth_token");
   try {
     const response = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(formData),
       signal,
@@ -48,7 +50,7 @@ export const createCodeConnect = async (
     if (error instanceof DOMException && error.name === "AbortError") {
       console.warn("Petición cancelada por el usuario o timeout.");
       throw {
-        message: "Petición cancelada",
+        message: "Petició cancel·lada",
         code: "ABORTED",
       } as CodeConnectError;
     }


### PR DESCRIPTION
**What**
- As per requested on backend side, updated createCodeConnect function to retrieve and send auth_token to the backend.

**Testing**
- Updated corresponding test
- Added missing aborted request case to the corresponding test

NB: removing the localStorage use for token is already in the backlog. For now I have no other workaround