### PR TITLE
feat(db): add ligas migration with user_id FK and points default 0

### DIFF
--- a/backend/src/database/migrations/2026_04_24_100000_create_ligas_table.php
+++ b/backend/src/database/migrations/2026_04_24_100000_create_ligas_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ligas', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('points')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ligas');
+    }
+};


### PR DESCRIPTION
### Summary
Creates the `ligas` database table as part of the Liga CRUD feature (User Story 1).

### Changes
- Added migration `2026_04_24_100000_create_ligas_table.php` under `backend/src/database/migrations/`

### Schema
| Column | Type | Notes |
|--------|------|-------|
| id | bigint | PK, auto-increment |
| user_id | foreignId | FK → users, cascade on delete |
| points | unsignedInteger | default 0 |
| timestamps | — | created_at, updated_at |

## Testing
- `php artisan migrate` runs without errors ✅
- All four columns verified via `Schema::getColumnListing('ligas')` ✅
- `php artisan migrate:rollback --step=1` removes table cleanly ✅
- `php artisan migrate` re-runs without errors ✅

## Notes
- File created manually under `backend/src/` to avoid artisan path issues