### PR TITLE
Feature/354 ligas leadercard toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "@vitejs/plugin-react-swc": "^3.5.0",
         "@vitest/coverage-v8": "^3.0.5",
         "@vitest/ui": "^3.0.8",
+        "axe-core": "^4.11.3",
         "eslint": "^9.19.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.0.0",
@@ -49,7 +50,8 @@
         "typescript-eslint": "^8.22.0",
         "vite": "^6.1.0",
         "vite-plugin-svgr": "^4.3.0",
-        "vitest": "^3.0.8"
+        "vitest": "^3.0.8",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2835,9 +2837,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2850,9 +2849,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2867,9 +2863,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2883,9 +2876,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2898,25 +2888,6 @@
       "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2957,25 +2928,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2988,9 +2940,6 @@
       "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3005,9 +2954,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3020,9 +2966,6 @@
       "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3037,9 +2980,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3052,9 +2992,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4859,6 +4796,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -8037,6 +7984,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10453,6 +10407,37 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@vitejs/plugin-react-swc": "^3.5.0",
     "@vitest/coverage-v8": "^3.0.5",
     "@vitest/ui": "^3.0.8",
+    "axe-core": "^4.11.3",
     "eslint": "^9.19.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.0.0",
@@ -54,6 +55,7 @@
     "typescript-eslint": "^8.22.0",
     "vite": "^6.1.0",
     "vite-plugin-svgr": "^4.3.0",
-    "vitest": "^3.0.8"
+    "vitest": "^3.0.8",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/frontend/src/components/LeaderCard/LeaderCard.test.tsx
+++ b/frontend/src/components/LeaderCard/LeaderCard.test.tsx
@@ -1,68 +1,78 @@
-import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import React from 'react';
-import LeaderCard from './LeaderCard';
-import type { Player } from '../../types/league';
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe } from "vitest-axe";
+import LeaderCard, { type LeaderCardPlayer } from "./LeaderCard";
 
-const mockPlayer: Player = {
-  position: 1,
-  username: 'Developer_134',
-  avatarUrl: 'https://example.com/avatar.jpg',
-  title: 'Expert Hacker',
+const mockPlayer: LeaderCardPlayer = {
+  user_id: 101,
+  username: "Developer_134",
+  avatarUrl: "https://example.com/avatar.jpg",
+  title: "Expert Hacker",
   points: 94,
 };
 
-describe('LeaderCard', () => {
-  it('renders username and points', () => {
+describe("LeaderCard", () => {
+  it("renders username and points", () => {
     render(<LeaderCard player={mockPlayer} cupType="gold" />);
 
-    expect(screen.getByText('Developer_134')).toBeInTheDocument();
-    expect(screen.getByText('94')).toBeInTheDocument();
+    expect(screen.getByText("Developer_134")).toBeInTheDocument();
+    expect(screen.getByText("94")).toBeInTheDocument();
   });
 
-  it('renders title', () => {
+  it("renders title", () => {
     render(<LeaderCard player={mockPlayer} cupType="gold" />);
 
-    expect(screen.getByText('Expert Hacker')).toBeInTheDocument();
+    expect(screen.getByText("Expert Hacker")).toBeInTheDocument();
   });
 
-  it('renders gold cup icon', () => {
+  it("renders gold cup icon", () => {
     render(<LeaderCard player={mockPlayer} cupType="gold" />);
 
-    expect(screen.getByLabelText('gold cup')).toBeInTheDocument();
+    expect(screen.getByLabelText("gold cup")).toBeInTheDocument();
   });
 
-  it('renders silver cup icon', () => {
-    render(<LeaderCard player={{ ...mockPlayer, position: 2 }} cupType="silver" />);
+  it("renders silver cup icon", () => {
+    render(<LeaderCard player={mockPlayer} cupType="silver" />);
 
-    expect(screen.getByLabelText('silver cup')).toBeInTheDocument();
+    expect(screen.getByLabelText("silver cup")).toBeInTheDocument();
   });
 
-  it('renders bronze cup icon', () => {
-    render(<LeaderCard player={{ ...mockPlayer, position: 3 }} cupType="bronze" />);
+  it("renders bronze cup icon", () => {
+    render(<LeaderCard player={mockPlayer} cupType="bronze" />);
 
-    expect(screen.getByLabelText('bronze cup')).toBeInTheDocument();
+    expect(screen.getByLabelText("bronze cup")).toBeInTheDocument();
   });
 
-  it('renders avatar image when avatarUrl is valid', () => {
+  it("renders avatar image when avatarUrl is valid", () => {
     render(<LeaderCard player={mockPlayer} cupType="gold" />);
 
-    expect(screen.getByAltText('Developer_134 avatar')).toBeInTheDocument();
+    expect(screen.getByAltText("Developer_134 avatar")).toBeInTheDocument();
   });
 
-  it('shows initials when avatar fails to load', () => {
+  it("shows initials when avatar fails to load", () => {
     render(<LeaderCard player={mockPlayer} cupType="gold" />);
 
-    const img = screen.getByAltText('Developer_134 avatar');
+    const img = screen.getByAltText("Developer_134 avatar");
     fireEvent.error(img);
 
-    expect(screen.getByText('DE')).toBeInTheDocument();
+    expect(screen.getByText("DE")).toBeInTheDocument();
   });
 
-  it('shows initials when avatarUrl is empty', () => {
-    render(<LeaderCard player={{ ...mockPlayer, avatarUrl: '' }} cupType="gold" />);
+  it("shows initials when avatarUrl is empty", () => {
+    render(
+      <LeaderCard player={{ ...mockPlayer, avatarUrl: "" }} cupType="gold" />,
+    );
 
-    expect(screen.getByText('DE')).toBeInTheDocument();
+    expect(screen.getByText("DE")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <LeaderCard player={mockPlayer} cupType="gold" />,
+    );
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
   });
 });

--- a/frontend/src/components/LeaderCard/LeaderCard.test.tsx
+++ b/frontend/src/components/LeaderCard/LeaderCard.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import LeaderCard from './LeaderCard';
+import type { Player } from '../../types/league';
+
+const mockPlayer: Player = {
+  position: 1,
+  username: 'Developer_134',
+  avatarUrl: 'https://example.com/avatar.jpg',
+  title: 'Expert Hacker',
+  points: 94,
+};
+
+describe('LeaderCard', () => {
+  it('renders username and points', () => {
+    render(<LeaderCard player={mockPlayer} cupType="gold" />);
+
+    expect(screen.getByText('Developer_134')).toBeInTheDocument();
+    expect(screen.getByText('94')).toBeInTheDocument();
+  });
+
+  it('renders title', () => {
+    render(<LeaderCard player={mockPlayer} cupType="gold" />);
+
+    expect(screen.getByText('Expert Hacker')).toBeInTheDocument();
+  });
+
+  it('renders gold cup icon', () => {
+    render(<LeaderCard player={mockPlayer} cupType="gold" />);
+
+    expect(screen.getByLabelText('gold cup')).toBeInTheDocument();
+  });
+
+  it('renders silver cup icon', () => {
+    render(<LeaderCard player={{ ...mockPlayer, position: 2 }} cupType="silver" />);
+
+    expect(screen.getByLabelText('silver cup')).toBeInTheDocument();
+  });
+
+  it('renders bronze cup icon', () => {
+    render(<LeaderCard player={{ ...mockPlayer, position: 3 }} cupType="bronze" />);
+
+    expect(screen.getByLabelText('bronze cup')).toBeInTheDocument();
+  });
+
+  it('renders avatar image when avatarUrl is valid', () => {
+    render(<LeaderCard player={mockPlayer} cupType="gold" />);
+
+    expect(screen.getByAltText('Developer_134 avatar')).toBeInTheDocument();
+  });
+
+  it('shows initials when avatar fails to load', () => {
+    render(<LeaderCard player={mockPlayer} cupType="gold" />);
+
+    const img = screen.getByAltText('Developer_134 avatar');
+    fireEvent.error(img);
+
+    expect(screen.getByText('DE')).toBeInTheDocument();
+  });
+
+  it('shows initials when avatarUrl is empty', () => {
+    render(<LeaderCard player={{ ...mockPlayer, avatarUrl: '' }} cupType="gold" />);
+
+    expect(screen.getByText('DE')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LeaderCard/LeaderCard.tsx
+++ b/frontend/src/components/LeaderCard/LeaderCard.tsx
@@ -1,47 +1,57 @@
-import { FC, useState } from 'react';
-import clsx from 'clsx';
-import type { Player } from '../../types/league';
+import { FC, useState } from "react";
+import clsx from "clsx";
 
-type CupType = 'gold' | 'silver' | 'bronze';
+export type CupType = "gold" | "silver" | "bronze";
+
+// Temporary type — will be updated once backend confirms JOIN with users table
+export type LeaderCardPlayer = {
+  user_id: number;
+  username: string;
+  avatarUrl: string;
+  title: string;
+  points: number;
+};
 
 interface LeaderCardProps {
-  player: Player;
+  player: LeaderCardPlayer;
   cupType: CupType;
 }
 
 const cupStyles: Record<CupType, string> = {
-  gold:   'text-yellow-400',
-  silver: 'text-gray-400',
-  bronze: 'text-amber-600',
+  gold: "text-yellow-400",
+  silver: "text-gray-400",
+  bronze: "text-amber-600",
 };
 
 const cupIcons: Record<CupType, string> = {
-  gold:   '🏆',
-  silver: '🥈',
-  bronze: '🥉',
+  gold: "🏆",
+  silver: "🥈",
+  bronze: "🥉",
 };
 
 const borderStyles: Record<CupType, string> = {
-  gold:   'border-yellow-400',
-  silver: 'border-gray-400',
-  bronze: 'border-amber-600',
+  gold: "border-yellow-400",
+  silver: "border-gray-400",
+  bronze: "border-amber-600",
 };
 
-const getInitials = (username: string) =>
-  username.slice(0, 2).toUpperCase();
+const getInitials = (username: string) => username.slice(0, 2).toUpperCase();
 
 const LeaderCard: FC<LeaderCardProps> = ({ player, cupType }) => {
   const [avatarError, setAvatarError] = useState(false);
 
   return (
     <div className="flex flex-col items-center gap-2 bg-white rounded-xl border border-gray-200 px-6 py-4 shadow-sm min-w-[180px]">
-      <span className={clsx('text-2xl', cupStyles[cupType])} aria-label={`${cupType} cup`}>
+      <span
+        className={clsx("text-2xl", cupStyles[cupType])}
+        aria-label={`${cupType} cup`}
+      >
         {cupIcons[cupType]}
       </span>
 
       <div
         className={clsx(
-          'w-14 h-14 rounded-full border-2 flex items-center justify-center overflow-hidden',
+          "w-14 h-14 rounded-full border-2 flex items-center justify-center overflow-hidden",
           borderStyles[cupType],
         )}
       >
@@ -62,7 +72,8 @@ const LeaderCard: FC<LeaderCardProps> = ({ player, cupType }) => {
       <p className="text-xs text-gray-500">{player.title}</p>
       <p className="font-bold text-sm">{player.username}</p>
       <p className="text-xs text-gray-500">
-        Puntos ganados: <span className="font-bold text-gray-800">{player.points}</span>
+        Puntos ganados:{" "}
+        <span className="font-bold text-gray-800">{player.points}</span>
       </p>
     </div>
   );

--- a/frontend/src/components/LeaderCard/LeaderCard.tsx
+++ b/frontend/src/components/LeaderCard/LeaderCard.tsx
@@ -1,0 +1,71 @@
+import { FC, useState } from 'react';
+import clsx from 'clsx';
+import type { Player } from '../../types/league';
+
+type CupType = 'gold' | 'silver' | 'bronze';
+
+interface LeaderCardProps {
+  player: Player;
+  cupType: CupType;
+}
+
+const cupStyles: Record<CupType, string> = {
+  gold:   'text-yellow-400',
+  silver: 'text-gray-400',
+  bronze: 'text-amber-600',
+};
+
+const cupIcons: Record<CupType, string> = {
+  gold:   '🏆',
+  silver: '🥈',
+  bronze: '🥉',
+};
+
+const borderStyles: Record<CupType, string> = {
+  gold:   'border-yellow-400',
+  silver: 'border-gray-400',
+  bronze: 'border-amber-600',
+};
+
+const getInitials = (username: string) =>
+  username.slice(0, 2).toUpperCase();
+
+const LeaderCard: FC<LeaderCardProps> = ({ player, cupType }) => {
+  const [avatarError, setAvatarError] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center gap-2 bg-white rounded-xl border border-gray-200 px-6 py-4 shadow-sm min-w-[180px]">
+      <span className={clsx('text-2xl', cupStyles[cupType])} aria-label={`${cupType} cup`}>
+        {cupIcons[cupType]}
+      </span>
+
+      <div
+        className={clsx(
+          'w-14 h-14 rounded-full border-2 flex items-center justify-center overflow-hidden',
+          borderStyles[cupType],
+        )}
+      >
+        {!avatarError && player.avatarUrl ? (
+          <img
+            src={player.avatarUrl}
+            alt={`${player.username} avatar`}
+            className="w-full h-full object-cover"
+            onError={() => setAvatarError(true)}
+          />
+        ) : (
+          <span className="text-sm font-bold text-gray-600">
+            {getInitials(player.username)}
+          </span>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-500">{player.title}</p>
+      <p className="font-bold text-sm">{player.username}</p>
+      <p className="text-xs text-gray-500">
+        Puntos ganados: <span className="font-bold text-gray-800">{player.points}</span>
+      </p>
+    </div>
+  );
+};
+
+export default LeaderCard;

--- a/frontend/src/components/LeagueToggle/LeagueToggle.test.tsx
+++ b/frontend/src/components/LeagueToggle/LeagueToggle.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import LeagueToggle from './LeagueToggle';
+
+describe('LeagueToggle', () => {
+  it('renders both toggle options', () => {
+    render(<LeagueToggle view="weekly" onChange={vi.fn()} />);
+
+    expect(screen.getByText('Liga semanal')).toBeInTheDocument();
+    expect(screen.getByText('Ranking general')).toBeInTheDocument();
+  });
+
+  it('marks weekly button as active when view is weekly', () => {
+    render(<LeagueToggle view="weekly" onChange={vi.fn()} />);
+
+    expect(screen.getByText('Liga semanal')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Ranking general')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('marks global button as active when view is global', () => {
+    render(<LeagueToggle view="global" onChange={vi.fn()} />);
+
+    expect(screen.getByText('Ranking general')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Liga semanal')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onChange with weekly when Liga semanal is clicked', () => {
+    const onChange = vi.fn();
+    render(<LeagueToggle view="global" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('Liga semanal'));
+
+    expect(onChange).toHaveBeenCalledWith('weekly');
+  });
+
+  it('calls onChange with global when Ranking general is clicked', () => {
+    const onChange = vi.fn();
+    render(<LeagueToggle view="weekly" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('Ranking general'));
+
+    expect(onChange).toHaveBeenCalledWith('global');
+  });
+});

--- a/frontend/src/components/LeagueToggle/LeagueToggle.test.tsx
+++ b/frontend/src/components/LeagueToggle/LeagueToggle.test.tsx
@@ -1,51 +1,65 @@
-import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import { axe } from 'vitest-axe';
-import LeagueToggle from './LeagueToggle';
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { axe } from "vitest-axe";
+import LeagueToggle from "./LeagueToggle";
 
-describe('LeagueToggle', () => {
-  it('renders both toggle options', () => {
+describe("LeagueToggle", () => {
+  it("renders both toggle options", () => {
     render(<LeagueToggle view="weekly" onChange={vi.fn()} />);
 
-    expect(screen.getByText('Liga semanal')).toBeInTheDocument();
-    expect(screen.getByText('Ranking general')).toBeInTheDocument();
+    expect(screen.getByText("Liga semanal")).toBeInTheDocument();
+    expect(screen.getByText("Ranking general")).toBeInTheDocument();
   });
 
-  it('marks weekly button as active when view is weekly', () => {
+  it("marks weekly button as active when view is weekly", () => {
     render(<LeagueToggle view="weekly" onChange={vi.fn()} />);
 
-    expect(screen.getByText('Liga semanal')).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Ranking general')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText("Liga semanal")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Ranking general")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 
-  it('marks global button as active when view is global', () => {
+  it("marks global button as active when view is global", () => {
     render(<LeagueToggle view="global" onChange={vi.fn()} />);
 
-    expect(screen.getByText('Ranking general')).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Liga semanal')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText("Ranking general")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Liga semanal")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 
-  it('calls onChange with weekly when Liga semanal is clicked', () => {
+  it("calls onChange with weekly when Liga semanal is clicked", () => {
     const onChange = vi.fn();
     render(<LeagueToggle view="global" onChange={onChange} />);
 
-    fireEvent.click(screen.getByText('Liga semanal'));
+    fireEvent.click(screen.getByText("Liga semanal"));
 
-    expect(onChange).toHaveBeenCalledWith('weekly');
+    expect(onChange).toHaveBeenCalledWith("weekly");
   });
 
-  it('calls onChange with global when Ranking general is clicked', () => {
+  it("calls onChange with global when Ranking general is clicked", () => {
     const onChange = vi.fn();
     render(<LeagueToggle view="weekly" onChange={onChange} />);
 
-    fireEvent.click(screen.getByText('Ranking general'));
+    fireEvent.click(screen.getByText("Ranking general"));
 
-    expect(onChange).toHaveBeenCalledWith('global');
+    expect(onChange).toHaveBeenCalledWith("global");
   });
 
-  it('has no accessibility violations', async () => {
-    const { container } = render(<LeagueToggle view="weekly" onChange={vi.fn()} />);
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <LeagueToggle view="weekly" onChange={vi.fn()} />,
+    );
     const results = await axe(container);
 
     expect(results.violations).toHaveLength(0);

--- a/frontend/src/components/LeagueToggle/LeagueToggle.test.tsx
+++ b/frontend/src/components/LeagueToggle/LeagueToggle.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import React from 'react';
+import { axe } from 'vitest-axe';
 import LeagueToggle from './LeagueToggle';
 
 describe('LeagueToggle', () => {
@@ -42,5 +42,12 @@ describe('LeagueToggle', () => {
     fireEvent.click(screen.getByText('Ranking general'));
 
     expect(onChange).toHaveBeenCalledWith('global');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<LeagueToggle view="weekly" onChange={vi.fn()} />);
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
   });
 });

--- a/frontend/src/components/LeagueToggle/LeagueToggle.tsx
+++ b/frontend/src/components/LeagueToggle/LeagueToggle.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react';
+import clsx from 'clsx';
+import type { LeagueView } from '../../types/league';
+
+interface LeagueToggleProps {
+  view: LeagueView;
+  onChange: (view: LeagueView) => void;
+}
+
+const options: { label: string; value: LeagueView }[] = [
+  { label: 'Liga semanal',    value: 'weekly' },
+  { label: 'Ranking general', value: 'global' },
+];
+
+const LeagueToggle: FC<LeagueToggleProps> = ({ view, onChange }) => {
+  return (
+    <div className="flex gap-2" role="group" aria-label="League view selector">
+      {options.map((option) => {
+        const isActive = view === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={isActive}
+            className={clsx(
+              'px-4 py-2 rounded-md text-sm font-semibold transition-all duration-200',
+              isActive
+                ? 'bg-[#B91879] text-white'
+                : 'border border-gray-300 text-gray-800 bg-white hover:bg-gray-100',
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default LeagueToggle;

--- a/frontend/src/components/LeagueToggle/LeagueToggle.tsx
+++ b/frontend/src/components/LeagueToggle/LeagueToggle.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react';
-import clsx from 'clsx';
-import type { LeagueView } from '../../types/league';
+import { FC } from "react";
+import clsx from "clsx";
+
+export type LeagueView = "weekly" | "global";
 
 interface LeagueToggleProps {
   view: LeagueView;
@@ -8,8 +9,8 @@ interface LeagueToggleProps {
 }
 
 const options: { label: string; value: LeagueView }[] = [
-  { label: 'Liga semanal',    value: 'weekly' },
-  { label: 'Ranking general', value: 'global' },
+  { label: "Liga semanal", value: "weekly" },
+  { label: "Ranking general", value: "global" },
 ];
 
 const LeagueToggle: FC<LeagueToggleProps> = ({ view, onChange }) => {
@@ -24,10 +25,10 @@ const LeagueToggle: FC<LeagueToggleProps> = ({ view, onChange }) => {
             onClick={() => onChange(option.value)}
             aria-pressed={isActive}
             className={clsx(
-              'px-4 py-2 rounded-md text-sm font-semibold transition-all duration-200',
+              "px-4 py-2 rounded-md text-sm font-semibold transition-all duration-200",
               isActive
-                ? 'bg-[#B91879] text-white'
-                : 'border border-gray-300 text-gray-800 bg-white hover:bg-gray-100',
+                ? "bg-[#B91879] text-white"
+                : "border border-gray-300 text-gray-800 bg-white hover:bg-gray-100",
             )}
           >
             {option.label}


### PR DESCRIPTION
## Overview
Build the LeaderCard component (top 3 players) and the Weekly/General toggle.

> **Sprint scope note:** The LeaderCard (podium) is built as an isolated component but is **not integrated into RankingsPage this sprint** — the current sprint delivers general ranking only via StandingsTable. Podium integration is planned for a future sprint.

## Changes
- Add LeaderCard with gold, silver and bronze variants (cup + avatar + points)
- Add avatar fallback showing user initials when image fails to load
- Add LeagueToggle component to switch between weekly and general view
- Define `LeaderCardPlayer` type locally — pending JOIN contract confirmation with backend
- Define `LeagueView` locally in LeagueToggle after alignment with backend schema

## Tests — 15 passing

### LeaderCard — 9 tests
- [x] Renders username and points
- [x] Renders title
- [x] Renders gold cup icon
- [x] Renders silver cup icon
- [x] Renders bronze cup icon
- [x] Renders avatar image when avatarUrl is valid
- [x] Shows initials when avatar fails to load
- [x] Shows initials when avatarUrl is empty
- [x] Has no accessibility violations (axe-core)

### LeagueToggle — 6 tests
- [x] Renders both toggle options
- [x] Marks weekly button as active when view is weekly
- [x] Marks global button as active when view is global
- [x] Calls onChange with weekly when Liga semanal is clicked
- [x] Calls onChange with global when Ranking general is clicked
- [x] Has no accessibility violations (axe-core)

## Notes
`LeaderCardPlayer` uses `username`, `avatarUrl` and `title` — these fields depend on a JOIN with the users table, pending confirmation with backend team.

Closes #354