### PR TITLE
feat: add LigaFactory, LigaSeeder and register in DatabaseSeeder

### DIFF
--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Liga extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'points',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/src/database/factories/LigaFactory.php
+++ b/backend/src/database/factories/LigaFactory.php
@@ -14,7 +14,7 @@ class LigaFactory extends Factory
 {
     public function definition(): array
     {
-        return[
+        return [
             'user_id' => User::factory(),
             'points' => fake()->numberBetween(0, 100),
         ];

--- a/backend/src/database/factories/LigaFactory.php
+++ b/backend/src/database/factories/LigaFactory.php
@@ -1,0 +1,22 @@
+<?php 
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** 
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Liga> 
+ */
+class LigaFactory extends Factory
+{
+    public function definition(): array
+    {
+        return[
+            'user_id' => User::factory(),
+            'points' => fake()->numberBetween(0, 100),
+        ];
+    }
+}

--- a/backend/src/database/seeders/DatabaseSeeder.php
+++ b/backend/src/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,8 @@ use Database\Seeders\ForumSeeder;
 use Database\Seeders\RoleSeeder;
 use Database\Seeders\PermissionSeeder;
 use Database\Seeders\RolePermissionSeeder;
+use Database\Seeders\LigaSeeder;
+
 
 class DatabaseSeeder extends Seeder
 {
@@ -30,7 +32,8 @@ class DatabaseSeeder extends Seeder
             RoleSeeder::class,              
             PermissionSeeder::class,       
             RolePermissionSeeder::class,    
-            UserSeeder::class,              
+            UserSeeder::class, 
+            LigaSeeder::class,             
             TagSeeder::class,               
             ResourceSeeder::class,         
             //BookmarkSeeder::class,         

--- a/backend/src/database/seeders/LigaSeeder.php
+++ b/backend/src/database/seeders/LigaSeeder.php
@@ -20,5 +20,7 @@ class LigaSeeder extends Seeder
                 ]);
             }
         });
+
+        Liga::factory()->count(5)->create();
     }
 }

--- a/backend/src/database/seeders/LigaSeeder.php
+++ b/backend/src/database/seeders/LigaSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class LigaSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::all()->each(function(User $user) {
+            if(! Liga::where('user_id', $user->id)->exists()) {
+                Liga::create([
+                    'user_id' => $user->id,
+                    'points' => rand(0, 100),
+                ]);
+            }
+        });
+    }
+}

--- a/backend/src/database/seeders/LigaSeeder.php
+++ b/backend/src/database/seeders/LigaSeeder.php
@@ -16,7 +16,7 @@ class LigaSeeder extends Seeder
             if(! Liga::where('user_id', $user->id)->exists()) {
                 Liga::create([
                     'user_id' => $user->id,
-                    'points' => rand(0, 100),
+                    'points' => fake()->numberBetween(0, 100),
                 ]);
             }
         });

--- a/backend/src/tests/Feature/LigaTests/LigaFactorySeederTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaFactorySeederTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\LigaTests;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaFactorySeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_liga_factory_creates_liga(): void
+    {
+        $liga = Liga::factory()->create();
+
+        $this->assertDatabaseHas('ligas', [
+            'id' => $liga->id,
+            'user_id' => $liga->user_id,
+        ]);
+    }
+
+    public function test_liga_factory_points_are_within_valid_range(): void
+    {
+        $liga = Liga::factory()->create();
+
+        $this->assertGreaterThanOrEqual(0, $liga->points);
+        $this->assertLessThanOrEqual(100, $liga->points);
+    }
+
+    public function test_liga_factory_creates_associated_user(): void
+    {
+        $liga = Liga::factory()->create();
+
+        $this->assertDatabaseHas('users', ['id' => $liga->user_id]);
+    }
+
+    public function test_liga_seeder_creates_liga_for_each_existing_user(): void
+    {
+        $user = User::factory()->count(3)->create();
+
+        (new \Database\Seeders\LigaSeeder())->run();
+
+        foreach ($user as $user) {
+            $this->assertDatabaseHas('ligas', ['user_id' => $user->id]);
+        }
+    }
+
+    public function test_liga_seeder_does_not_duplicate_ligas(): void
+    {
+        $user = User::factory()->create();
+        Liga::create(['user_id' => $user->id, 'points' => 50]);
+
+        (new \Database\Seeders\LigaSeeder())->run();
+
+        $this->assertCount(1, Liga::where('user_id', $user->id)->get());
+    }
+
+    public function test_liga_seeder_creates_five_test_ligas_via_factory(): void
+    {
+        (new \Database\Seeders\LigaSeeder())->run();
+
+        $this->assertGreaterThanOrEqual(5, Liga::count());
+    }
+}


### PR DESCRIPTION
This PR adds the factory and seeder infrastructure for the Liga feature.

LigaFactory was created to generate test Liga entries with a random points value between 0 and 100, delegating user creation to UserFactory. LigaSeeder was added to populate the ligas table with one entry per existing user, skipping any user that already has an entry to avoid duplicates. Finally, LigaSeeder was registered in DatabaseSeeder immediately after UserSeeder to guarantee that all users exist before the seeder runs.

Tasks 6 and 7 were grouped into this PR together with task 5 because they form a single coherent unit — the factory is only useful if there is a seeder to use it, and the seeder has no effect unless it is registered. Splitting them across separate PRs would have left the codebase in an incomplete state.
