### PR TITLE
feat(models): add Liga model and ligaEntry HasOne relation on User

### DIFF
--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -17,21 +17,12 @@ class Liga extends Model
         'points',
     ];
 
-<<<<<<< 302-model-creation
     protected $casts = [
         'points' => 'integer',
     ];
 
-=======
->>>>>>> develop
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
-<<<<<<< 302-model-creation
-
 }
-
-=======
-}
->>>>>>> develop

--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Liga extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'points',
+    ];
+
+    protected $casts = [
+        'points' => 'integer',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+}
+

--- a/backend/src/app/Models/User.php
+++ b/backend/src/app/Models/User.php
@@ -9,6 +9,9 @@ use Spatie\Permission\Traits\HasRoles;
 use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+
 
 class User extends Authenticatable
 {
@@ -107,5 +110,11 @@ class User extends Authenticatable
     {
         return $this->hasMany(TicketComment::class);
     }
+
+    public function ligaEntry(): HasOne
+    {
+      return $this->hasOne(Liga::class);
+    }
+
 
 }

--- a/backend/src/tests/Unit/LigaModelTest.php
+++ b/backend/src/tests/Unit/LigaModelTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use PHPUnit\Framework\TestCase;
+
+class LigaModelTest extends TestCase
+{
+    public function testPointsIsCastToInteger(): void
+    {
+        $liga = new Liga();
+
+        $this->assertArrayHasKey('points', $liga->getCasts());
+        $this->assertEquals('integer', $liga->getCasts()['points']);
+    }
+
+    public function testLigaEntryRelationOnUserReturnsHasOne(): void
+    {
+    $reflection = new \ReflectionMethod(User::class, 'ligaEntry');
+    $returnType = $reflection->getReturnType()->getName();
+
+    $this->assertEquals(HasOne::class, $returnType);
+    }
+
+}
+


### PR DESCRIPTION
Created the Liga Eloquent model with user_id and points as fillable fields, integer cast on points, and a BelongsTo relationship to User.

Added the inverse ligaEntry(): HasOne relationship to the User model so that $user->ligaEntry returns the user's liga row or null.