### PR TITLE
feat(tickets): add tickets GET endpoint and config (#333)

### DIFF
--- a/frontend/src/api/__tests__/endPointTickets.test.ts
+++ b/frontend/src/api/__tests__/endPointTickets.test.ts
@@ -46,7 +46,9 @@ describe("fetchAllTickets", () => {
 
     const result = await fetchAllTickets();
     expect(result).toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalledWith(new Error("Failed to fetch tickets"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      new Error("Failed to fetch tickets"),
+    );
   });
 
   it("should handle network errors (fetch throw)", async () => {

--- a/frontend/src/api/__tests__/endPointTickets.test.ts
+++ b/frontend/src/api/__tests__/endPointTickets.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchTickets } from "./endPointTickets";
+import { fetchAllTickets } from "../endPointTickets";
 
-vi.mock("../config", () => ({
+vi.mock("../../config", () => ({
   API_URL: "http://localhost:3000",
   END_POINTS: {
     tickets: {
@@ -14,7 +14,7 @@ vi.mock("../config", () => ({
 const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
 
-describe("fetchTickets", () => {
+describe("fetchAllTickets", () => {
   const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe("fetchTickets", () => {
       json: async () => mockData,
     });
 
-    const result = await fetchTickets();
+    const result = await fetchAllTickets();
     expect(result).toEqual(mockData);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -44,7 +44,7 @@ describe("fetchTickets", () => {
       json: async () => ({ data: mockInnerData }),
     });
 
-    const result = await fetchTickets();
+    const result = await fetchAllTickets();
     expect(result).toEqual(mockInnerData);
   });
 
@@ -55,7 +55,7 @@ describe("fetchTickets", () => {
       statusText: "Server Error",
     });
 
-    const result = await fetchTickets();
+    const result = await fetchAllTickets();
     expect(result).toBeUndefined();
     expect(consoleSpy).toHaveBeenCalled();
   });
@@ -64,7 +64,7 @@ describe("fetchTickets", () => {
     const networkError = new Error("Network Error");
     fetchMock.mockRejectedValue(networkError);
 
-    await fetchTickets();
+    await fetchAllTickets();
     expect(consoleSpy).toHaveBeenCalledWith(networkError);
   });
 });

--- a/frontend/src/api/__tests__/endPointTickets.test.ts
+++ b/frontend/src/api/__tests__/endPointTickets.test.ts
@@ -25,20 +25,8 @@ describe("fetchAllTickets", () => {
     consoleSpy.mockClear();
   });
 
-  it("should return the data correctly if the API returns a direct array", async () => {
-    const mockData = [{ id: 1, name: "Bug login" }];
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    });
-
-    const result = await fetchAllTickets();
-    expect(result).toEqual(mockData);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('should return "data.data" if the API returns a wrapped object', async () => {
-    const mockInnerData = [{ id: 2, name: "Bug logout" }];
+  it("should return the data correctly", async () => {
+    const mockInnerData = [{ id: 1, name: "Bug login" }];
     fetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ data: mockInnerData }),
@@ -46,6 +34,7 @@ describe("fetchAllTickets", () => {
 
     const result = await fetchAllTickets();
     expect(result).toEqual(mockInnerData);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("should make a console.error if the response is not OK", async () => {
@@ -57,7 +46,7 @@ describe("fetchAllTickets", () => {
 
     const result = await fetchAllTickets();
     expect(result).toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(new Error("Failed to fetch tickets"));
   });
 
   it("should handle network errors (fetch throw)", async () => {

--- a/frontend/src/api/endPointTickets.test.ts
+++ b/frontend/src/api/endPointTickets.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fetchTickets } from "./endPointTickets";
-import { API_URL, END_POINTS } from "../config";
 
 vi.mock("../config", () => ({
   API_URL: "http://localhost:3000",

--- a/frontend/src/api/endPointTickets.test.ts
+++ b/frontend/src/api/endPointTickets.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchTickets } from "./endPointTickets";
+import { API_URL, END_POINTS } from "../config";
+
+vi.mock("../config", () => ({
+  API_URL: "http://localhost:3000",
+  END_POINTS: {
+    tickets: {
+      get: "/api/tickets",
+      post: "/api/tickets",
+    },
+  },
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("fetchTickets", () => {
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  it("should return the data correctly if the API returns a direct array", async () => {
+    const mockData = [{ id: 1, name: "Bug login" }];
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await fetchTickets();
+    expect(result).toEqual(mockData);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return "data.data" if the API returns a wrapped object', async () => {
+    const mockInnerData = [{ id: 2, name: "Bug logout" }];
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: mockInnerData }),
+    });
+
+    const result = await fetchTickets();
+    expect(result).toEqual(mockInnerData);
+  });
+
+  it("should make a console.error if the response is not OK", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+    });
+
+    const result = await fetchTickets();
+    expect(result).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("should handle network errors (fetch throw)", async () => {
+    const networkError = new Error("Network Error");
+    fetchMock.mockRejectedValue(networkError);
+
+    await fetchTickets();
+    expect(consoleSpy).toHaveBeenCalledWith(networkError);
+  });
+});

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,7 +1,7 @@
 // src/api/endPointTickets.ts
 import { API_URL, END_POINTS } from "../config";
 
-export const fetchTickets = async () => {
+export const fetchAllTickets = async () => {
   const url = `${API_URL}${END_POINTS.tickets.get}`;
   try {
     const response = await fetch(url);

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,4 +1,3 @@
-// src/api/endPointTickets.ts
 import { API_URL, END_POINTS } from "../config";
 
 export const fetchAllTickets = async () => {
@@ -7,7 +6,7 @@ export const fetchAllTickets = async () => {
     const response = await fetch(url);
     if (!response.ok) throw new Error("Failed to fetch tickets");
     const data = await response.json();
-    return Array.isArray(data) ? data : data.data;
+    return data.data;
   } catch (error: unknown) {
     console.error(error);
   }

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,0 +1,14 @@
+// src/api/endPointTickets.ts
+import { API_URL, END_POINTS } from "../config";
+
+export const fetchTickets = async () => {
+  const url = `${API_URL}${END_POINTS.tickets.get}`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error("Failed to fetch tickets");
+    const data = await response.json();
+    return Array.isArray(data) ? data : data.data;
+  } catch (error: unknown) {
+    console.error(error);
+  }
+};

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -27,8 +27,8 @@ describe("Configuración de la API", () => {
   });
 
   it("should have tickets endpoints", async () => {
-      const { END_POINTS } = await import("./config");
-      expect(END_POINTS.tickets.get).toBe("tickets");
-      expect(END_POINTS.tickets.post).toBe("tickets");
+    const { END_POINTS } = await import("./config");
+    expect(END_POINTS.tickets.get).toBe("tickets");
+    expect(END_POINTS.tickets.post).toBe("tickets");
   });
 });

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -26,8 +26,9 @@ describe("Configuración de la API", () => {
     expect(END_POINTS.resources.lists).toBe("resources");
   });
 
-  it("should have tickets endpoints", () => {
-    expect(END_POINTS.tickets.get).toBe("tickets");
-    expect(END_POINTS.tickets.post).toBe("tickets");
-});
+  it("should have tickets endpoints", async () => {
+      const { END_POINTS } = await import("./config");
+      expect(END_POINTS.tickets.get).toBe("tickets");
+      expect(END_POINTS.tickets.post).toBe("tickets");
+  });
 });

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -25,4 +25,9 @@ describe("Configuración de la API", () => {
     const { END_POINTS } = await import("./config");
     expect(END_POINTS.resources.lists).toBe("resources");
   });
+
+  it("should have tickets endpoints", () => {
+    expect(END_POINTS.tickets.get).toBe("tickets");
+    expect(END_POINTS.tickets.post).toBe("tickets");
+});
 });

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -14,7 +14,8 @@ type EndPoints =
   | "tags/by-category"
   | "technical-tests"
   | "codeconnect"
-  | "auth";
+  | "auth"
+  | "tickets";
 
 const END_POINTS = {
   resources: {
@@ -57,6 +58,10 @@ const END_POINTS = {
     getAuthUser: "auth/github/user" as EndPoints,
     getCurrentUser: "auth/me" as EndPoints,
     logout: "auth/logout" as EndPoints,
+  },
+  tickets: {
+    get: "tickets" as EndPoints,
+    post: "tickets" as EndPoints,
   },
 };
 


### PR DESCRIPTION
## What
Prepares the API layer for the ticketing system (GET only).

## Changes
- `frontend/src/config.ts` — added `tickets` to `EndPoints` type and `END_POINTS` object with `get` and `post`
- `frontend/src/api/endPointTickets.ts` — new file with `fetchTickets` function (GET)
- `frontend/src/api/endPointTickets.test.ts` — unit tests for `fetchTickets`
- `frontend/src/config.test.ts` — added test to verify tickets endpoints exist in config

## Notes
- `post` is registered in config but the function is not implemented yet
- All ticket endpoints are protected with `auth:sanctum` on the backend