### PR TITLE
Add fetch to get all tickets

### DIFF
--- a/frontend/src/hooks/__tests__/useTicketingGetAll.test.ts
+++ b/frontend/src/hooks/__tests__/useTicketingGetAll.test.ts
@@ -6,7 +6,6 @@ import type {
   ApiTicketData,
   ApiTicketsResponse,
 } from "../../types/ticketingTypes";
-
 import { useTicketingGetAll } from "../useTicketingGetAll";
 
 const makeTicket = (overrides: Partial<ApiTicketData> = {}): ApiTicketData => {
@@ -34,6 +33,22 @@ const makeTicket = (overrides: Partial<ApiTicketData> = {}): ApiTicketData => {
   };
 };
 
+const renderUseTicketingGetAllWithResponse = async (
+  response: ApiTicketsResponse,
+) => {
+  vi.spyOn(axios, "get").mockResolvedValueOnce({
+    data: response,
+  });
+
+  const renderedHook = renderHook(() => useTicketingGetAll());
+
+  await waitFor(() => {
+    expect(renderedHook.result.current.isLoading).toBe(false);
+  });
+
+  return renderedHook.result;
+};
+
 describe("useTicketingGetAll", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,7 +59,7 @@ describe("useTicketingGetAll", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns tickets when API success=true", async () => {
+  it("stores tickets when the API returns a successful response with data", async () => {
     const apiTickets: ApiTicketData[] = [
       makeTicket(),
       makeTicket({ id: 2, name: "Error recursos" }),
@@ -55,57 +70,33 @@ describe("useTicketingGetAll", () => {
       data: apiTickets,
     };
 
-    vi.spyOn(axios, "get").mockResolvedValueOnce({
-      data: response,
-    });
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+    const result = await renderUseTicketingGetAllWithResponse(response);
 
     expect(axios.get).toHaveBeenCalledTimes(1);
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.tickets).toEqual(apiTickets);
   });
 
-  it("returns empty tickets when API success=true and data is empty", async () => {
+  it("stores an empty ticket list when the API returns a successful response without data", async () => {
     const response: ApiTicketsResponse = {
       success: true,
       data: [],
     };
 
-    vi.spyOn(axios, "get").mockResolvedValueOnce({
-      data: response,
-    });
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+    const result = await renderUseTicketingGetAllWithResponse(response);
 
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.tickets).toEqual([]);
   });
 
-  it("sets errorMessage when API success=false", async () => {
+  it("sets an error message when the API returns an unsuccessful response", async () => {
     const response: ApiTicketsResponse = {
       success: false,
       message: "Unauthorized",
       data: [],
     };
 
-    vi.spyOn(axios, "get").mockResolvedValueOnce({
-      data: response,
-    });
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+    const result = await renderUseTicketingGetAllWithResponse(response);
 
     expect(result.current.tickets).toEqual([]);
     expect(result.current.errorMessage).toBe("Unauthorized");

--- a/frontend/src/hooks/__tests__/useTicketingGetAll.test.ts
+++ b/frontend/src/hooks/__tests__/useTicketingGetAll.test.ts
@@ -1,10 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import axios, {
-  AxiosError,
-  AxiosHeaders,
-  CanceledError,
-  type InternalAxiosRequestConfig,
-} from "axios";
+import axios from "axios";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
@@ -114,81 +109,5 @@ describe("useTicketingGetAll", () => {
 
     expect(result.current.tickets).toEqual([]);
     expect(result.current.errorMessage).toBe("Unauthorized");
-  });
-
-  it("sets errorMessage when API response shape is invalid", async () => {
-    vi.spyOn(axios, "get").mockResolvedValueOnce({
-      data: { nope: true },
-    });
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.tickets).toEqual([]);
-    expect(result.current.errorMessage).toBe("Invalid API response shape");
-  });
-
-  it("sets errorMessage on AxiosError with API message", async () => {
-    const axiosRequestConfig: InternalAxiosRequestConfig = {
-      headers: new AxiosHeaders(),
-    };
-
-    const axiosError = new AxiosError(
-      "Request failed",
-      "ERR_BAD_REQUEST",
-      axiosRequestConfig,
-      undefined,
-      {
-        data: {
-          message: "Token invalid",
-        },
-        status: 401,
-        statusText: "Unauthorized",
-        headers: new AxiosHeaders(),
-        config: axiosRequestConfig,
-      },
-    );
-
-    vi.spyOn(axios, "get").mockRejectedValueOnce(axiosError);
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.tickets).toEqual([]);
-    expect(result.current.errorMessage).toBe("Token invalid");
-  });
-
-  it("sets errorMessage on generic error", async () => {
-    vi.spyOn(axios, "get").mockRejectedValueOnce(new Error("Network down"));
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.tickets).toEqual([]);
-    expect(result.current.errorMessage).toBe("Network down");
-  });
-
-  it("ignores cancelled request and does not set errorMessage", async () => {
-    vi.spyOn(axios, "get").mockRejectedValueOnce(
-      new CanceledError("Request cancelled"),
-    );
-
-    const { result } = renderHook(() => useTicketingGetAll());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.errorMessage).toBeNull();
-    expect(result.current.tickets).toEqual([]);
   });
 });

--- a/frontend/src/hooks/__tests__/useTicketingGetAll.test.ts
+++ b/frontend/src/hooks/__tests__/useTicketingGetAll.test.ts
@@ -1,0 +1,194 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  CanceledError,
+  type InternalAxiosRequestConfig,
+} from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ApiTicketData,
+  ApiTicketsResponse,
+} from "../../types/ticketingTypes";
+
+import { useTicketingGetAll } from "../useTicketingGetAll";
+
+const makeTicket = (overrides: Partial<ApiTicketData> = {}): ApiTicketData => {
+  return {
+    id: 1,
+    code_connect_id: 10,
+    forum_answer_id: null,
+    name: "Error login",
+    incident_date: "2026-04-27",
+    affected_app: "wiki_frontend",
+    type: "error",
+    affected_function: "login",
+    description: "No es pot iniciar sessió",
+    status: "pending",
+    priority: "medium",
+    assignee_id: null,
+    closed_by: null,
+    closed_at: null,
+    created_at: "2026-04-27T10:00:00.000000Z",
+    updated_at: "2026-04-27T10:00:00.000000Z",
+    code_connect: null,
+    assignee: null,
+    closed_by_user: null,
+    ...overrides,
+  };
+};
+
+describe("useTicketingGetAll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue("fake-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns tickets when API success=true", async () => {
+    const apiTickets: ApiTicketData[] = [
+      makeTicket(),
+      makeTicket({ id: 2, name: "Error recursos" }),
+    ];
+
+    const response: ApiTicketsResponse = {
+      success: true,
+      data: apiTickets,
+    };
+
+    vi.spyOn(axios, "get").mockResolvedValueOnce({
+      data: response,
+    });
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.tickets).toEqual(apiTickets);
+  });
+
+  it("returns empty tickets when API success=true and data is empty", async () => {
+    const response: ApiTicketsResponse = {
+      success: true,
+      data: [],
+    };
+
+    vi.spyOn(axios, "get").mockResolvedValueOnce({
+      data: response,
+    });
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.tickets).toEqual([]);
+  });
+
+  it("sets errorMessage when API success=false", async () => {
+    const response: ApiTicketsResponse = {
+      success: false,
+      message: "Unauthorized",
+      data: [],
+    };
+
+    vi.spyOn(axios, "get").mockResolvedValueOnce({
+      data: response,
+    });
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.tickets).toEqual([]);
+    expect(result.current.errorMessage).toBe("Unauthorized");
+  });
+
+  it("sets errorMessage when API response shape is invalid", async () => {
+    vi.spyOn(axios, "get").mockResolvedValueOnce({
+      data: { nope: true },
+    });
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.tickets).toEqual([]);
+    expect(result.current.errorMessage).toBe("Invalid API response shape");
+  });
+
+  it("sets errorMessage on AxiosError with API message", async () => {
+    const axiosRequestConfig: InternalAxiosRequestConfig = {
+      headers: new AxiosHeaders(),
+    };
+
+    const axiosError = new AxiosError(
+      "Request failed",
+      "ERR_BAD_REQUEST",
+      axiosRequestConfig,
+      undefined,
+      {
+        data: {
+          message: "Token invalid",
+        },
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new AxiosHeaders(),
+        config: axiosRequestConfig,
+      },
+    );
+
+    vi.spyOn(axios, "get").mockRejectedValueOnce(axiosError);
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.tickets).toEqual([]);
+    expect(result.current.errorMessage).toBe("Token invalid");
+  });
+
+  it("sets errorMessage on generic error", async () => {
+    vi.spyOn(axios, "get").mockRejectedValueOnce(new Error("Network down"));
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.tickets).toEqual([]);
+    expect(result.current.errorMessage).toBe("Network down");
+  });
+
+  it("ignores cancelled request and does not set errorMessage", async () => {
+    vi.spyOn(axios, "get").mockRejectedValueOnce(
+      new CanceledError("Request cancelled"),
+    );
+
+    const { result } = renderHook(() => useTicketingGetAll());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.tickets).toEqual([]);
+  });
+});

--- a/frontend/src/hooks/useTicketingGetAll.ts
+++ b/frontend/src/hooks/useTicketingGetAll.ts
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import { API_URL } from "../config";
 
 import type {
-  ApiTicketsResponse,
   ApiTicketData,
+  ApiTicketsResponse,
   TicketingError,
 } from "../types/ticketingTypes";
 
@@ -42,9 +42,10 @@ export const useTicketingGetAll = () => {
         const responseData = response.data;
 
         if (!responseData.success) {
-          throw {
-            message: responseData.message || "Invalid API response shape",
-          } as TicketingError;
+          setTickets([]);
+          setErrorMessage(responseData.message || "Invalid API response shape");
+
+          return;
         }
 
         setTickets(responseData.data);

--- a/frontend/src/hooks/useTicketingGetAll.ts
+++ b/frontend/src/hooks/useTicketingGetAll.ts
@@ -41,16 +41,6 @@ export const useTicketingGetAll = () => {
 
         const responseData = response.data;
 
-        if (
-          !responseData ||
-          typeof responseData.success !== "boolean" ||
-          !Array.isArray(responseData.data)
-        ) {
-          throw {
-            message: "Invalid API response shape",
-          } as TicketingError;
-        }
-
         if (!responseData.success) {
           throw {
             message: responseData.message || "Invalid API response shape",

--- a/frontend/src/hooks/useTicketingGetAll.ts
+++ b/frontend/src/hooks/useTicketingGetAll.ts
@@ -1,0 +1,95 @@
+import axios, { AxiosError, CanceledError } from "axios";
+import { useEffect, useState } from "react";
+
+import { API_URL } from "../config";
+
+import type {
+  ApiTicketsResponse,
+  ApiTicketData,
+  TicketingError,
+} from "../types/ticketingTypes";
+
+const isAbortLikeError = (value: unknown): boolean => {
+  return value instanceof CanceledError;
+};
+
+export const useTicketingGetAll = () => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [tickets, setTickets] = useState<ApiTicketData[]>([]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    const fetchTickets = async (): Promise<void> => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const token = localStorage.getItem("auth_token");
+
+        const response = await axios.get<ApiTicketsResponse>(
+          `${API_URL}tickets`,
+          {
+            headers: {
+              Accept: "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            signal: abortController.signal,
+          },
+        );
+
+        const responseData = response.data;
+
+        if (
+          !responseData ||
+          typeof responseData.success !== "boolean" ||
+          !Array.isArray(responseData.data)
+        ) {
+          throw {
+            message: "Invalid API response shape",
+          } as TicketingError;
+        }
+
+        if (!responseData.success) {
+          throw {
+            message: responseData.message || "Invalid API response shape",
+          } as TicketingError;
+        }
+
+        setTickets(responseData.data);
+      } catch (error: unknown) {
+        if (isAbortLikeError(error)) return;
+
+        if (error instanceof AxiosError) {
+          const responseData = error.response?.data as
+            | Partial<TicketingError>
+            | undefined;
+
+          setErrorMessage(
+            responseData?.message ||
+              error.message ||
+              "Error de connexió. Verifica la teva connexió a internet.",
+          );
+
+          return;
+        }
+
+        const message =
+          error && typeof error === "object" && "message" in error
+            ? String((error as { message: unknown }).message)
+            : "Unknown error";
+
+        setErrorMessage(message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTickets();
+
+    return () => abortController.abort();
+  }, []);
+
+  return { tickets, isLoading, errorMessage };
+};

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -43,7 +43,7 @@ export interface ApiTicketData {
   affected_function: AffectedFunction;
   description: string;
   status: TicketStatus;
-  priority: TicketPriority;
+  priority: TicketPriority | null;
   assignee_id: number | null;
   closed_by: number | null;
   closed_at: string | null;

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -1,0 +1,73 @@
+export type TicketStatus =
+  | "pending"
+  | "in_progress"
+  | "blocked"
+  | "ready"
+  | "closed";
+
+export type TicketPriority = "low" | "medium" | "high" | "critical";
+
+export type TicketType = "error" | "suggestion";
+
+export type AffectedApp =
+  | "wiki_frontend"
+  | "wiki_backend"
+  | "code_connect"
+  | "other";
+
+export type AffectedFunction =
+  | "login"
+  | "challenges"
+  | "resources"
+  | "profile"
+  | "technical_tests"
+  | "code_connect"
+  | "other";
+
+export interface TicketUserData {
+  id: number;
+  github_id?: string | null;
+  github_user_name?: string | null;
+  name?: string | null;
+  email?: string | null;
+}
+
+export interface ApiTicketData {
+  id: number;
+  code_connect_id: number;
+  forum_answer_id: number | null;
+  name: string;
+  incident_date: string;
+  affected_app: AffectedApp;
+  type: TicketType;
+  affected_function: AffectedFunction;
+  description: string;
+  status: TicketStatus;
+  priority: TicketPriority;
+  assignee_id: number | null;
+  closed_by: number | null;
+  closed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  code_connect?: TicketUserData | null;
+  assignee?: TicketUserData | null;
+  closed_by_user?: TicketUserData | null;
+}
+
+export interface ApiTicketsResponse {
+  success: boolean;
+  data: ApiTicketData[];
+  message?: string;
+}
+
+export interface TicketingError {
+  message: string;
+  status?: number;
+  code?: string;
+}
+
+export interface UseTicketingGetAllState {
+  tickets: ApiTicketData[];
+  isLoading: boolean;
+  errorMessage: string | null;
+}


### PR DESCRIPTION
## Add fetch to get all tickets

Implemented a custom React hook to fetch all tickets using Axios with proper authentication headers.  
Handled API response validation, including success flags and invalid response shapes.  
Added comprehensive error handling for Axios errors, network failures, and request cancellations.  
Included full test coverage for success, edge cases, and failure scenarios to ensure robustness.