### PR TITLE
feat: retrieve project owner in index and show endpoints

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -38,6 +38,12 @@ class ListProjectsController extends Controller
      *               @OA\Property(property="limit_date_inscription", type="string", format="date", nullable=true, example="2025-12-31"),
      *               @OA\Property(property="dev_front_number", type="integer", nullable=true, example=2),
      *               @OA\Property(property="dev_back_number", type="integer", nullable=true, example=2),
+     *               @OA\Property(
+     *                   property="owner",
+     *                   type="object",
+     *                   @OA\Property(property="id", type="integer", example=1),
+     *                   @OA\Property(property="name", type="string", example="John Doe")
+     *               ),
      * 
      * 
      *               @OA\Property(
@@ -58,7 +64,7 @@ class ListProjectsController extends Controller
     public function index(Request $request)
     {
 
-        $projects = ListProjects::with('contributorListProject.user')->get()->map(function ($project) {
+        $projects = ListProjects::with('user', 'contributorListProject.user')->get()->map(function ($project) {
             return [
                 'id' => $project->id,
                 'user_id' => $project->user_id,
@@ -71,6 +77,10 @@ class ListProjectsController extends Controller
                 'limit_date_inscription' => $project->limit_date_inscription,
                 'dev_front_number' => $project->dev_front_number,
                 'dev_back_number' => $project->dev_back_number,
+                'owner' => [
+                    'id' => $project->user->id,
+                    'name' => $project->user->name,
+                ],
 
                 'contributors' => $project->contributorListProject->map(function ($contributor) {
                     return [
@@ -104,6 +114,7 @@ class ListProjectsController extends Controller
      *      description="Project retrieved successfully",
      *      @OA\JsonContent(
      *           type="object",
+     *           @OA\Property(property="id", type="integer", example=1),
      *           @OA\Property(property="title", type="string", example="Project Alpha"),
      *           @OA\Property(property="time_duration", type="string", example="1 month"),
      *           @OA\Property(property="language_backend", type="string", example="PHP"),
@@ -114,6 +125,12 @@ class ListProjectsController extends Controller
      *           @OA\Property(property="limit_date_inscription", type="string", format="date", nullable=true, example="2025-12-31"),
      *           @OA\Property(property="dev_front_number", type="integer", nullable=true, example=2),
      *           @OA\Property(property="dev_back_number", type="integer", nullable=true, example=2),
+     *           @OA\Property(
+     *               property="owner",
+     *               type="object",
+     *               @OA\Property(property="id", type="integer", example=1),
+     *               @OA\Property(property="name", type="string", example="Macaulay Culkin")
+     *           ),
 
      *           @OA\Property(
      *               property="contributors",
@@ -134,7 +151,7 @@ class ListProjectsController extends Controller
      */
     public function show($id)
     {
-        $project = ListProjects::with('contributorListProject.user')->find($id);
+        $project = ListProjects::with('user', 'contributorListProject.user')->find($id);
 
         if (!$project) {
             return response()->json([
@@ -156,6 +173,10 @@ class ListProjectsController extends Controller
             'limit_date_inscription' => $project->limit_date_inscription,
             'dev_front_number' => $project->dev_front_number,
             'dev_back_number' => $project->dev_back_number,
+            'owner' => [
+                'id' => $project->user->id,
+                'name' => $project->user->name,
+            ],
 
             'contributors' => $project->contributorListProject->map(function ($contributor) {
                 return [

--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use App\Enums\LanguageEnum;
 use App\Http\Requests\ListProjectRequest;
 use App\Enums\ContributorStatusEnum;
+use App\Models\User;
 
 class ListProjectsController extends Controller
 {
@@ -61,6 +62,11 @@ class ListProjectsController extends Controller
      * )
      */
 
+    private function formatOwner(?User $user): ?array{
+
+        return $user ? ['id' => $user->id, 'name' => $user->name,] : null;
+    }
+
     public function index(Request $request)
     {
 
@@ -77,11 +83,7 @@ class ListProjectsController extends Controller
                 'limit_date_inscription' => $project->limit_date_inscription,
                 'dev_front_number' => $project->dev_front_number,
                 'dev_back_number' => $project->dev_back_number,
-                'owner' => [
-                    'id' => $project->user->id,
-                    'name' => $project->user->name,
-                ],
-
+                'owner' => $this->formatOwner($project->user),
                 'contributors' => $project->contributorListProject->map(function ($contributor) {
                     return [
                         'name' => $contributor->user->name,
@@ -173,11 +175,7 @@ class ListProjectsController extends Controller
             'limit_date_inscription' => $project->limit_date_inscription,
             'dev_front_number' => $project->dev_front_number,
             'dev_back_number' => $project->dev_back_number,
-            'owner' => [
-                'id' => $project->user->id,
-                'name' => $project->user->name,
-            ],
-
+            'owner' => $this->formatOwner($project->user),
             'contributors' => $project->contributorListProject->map(function ($contributor) {
                 return [
                     'name' => $contributor->user->name,

--- a/backend/src/tests/Feature/ListProjects/ListProjectsIndexTest.php
+++ b/backend/src/tests/Feature/ListProjects/ListProjectsIndexTest.php
@@ -28,6 +28,7 @@ class ListProjectsIndexTest extends TestCase
 
         $this->projectOne = ListProjects::factory()->create([
             'id' => 1,
+            'user_id' => $this->userOne->id,
             'title' => 'Project Alpha',
             'time_duration' => '1 month',
             'language_backend' => LanguageEnum::PHP->value,
@@ -119,6 +120,17 @@ class ListProjectsIndexTest extends TestCase
             'limit_date_inscription' => $this->projectOne->limit_date_inscription,
             'dev_front_number' => $this->projectOne->dev_front_number,
             'dev_back_number' => $this->projectOne->dev_back_number,
+        ]);
+    }
+
+     public function test_index_returns_owner():void{
+        $response = $this->Get("/api/codeconnect");
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'owner' => [
+                'id' => $this->projectOne->user->id,
+                'name'=> $this->projectOne->user->name,
+            ]
         ]);
     }
 

--- a/backend/src/tests/Feature/ListProjects/ListProjectsShowTest.php
+++ b/backend/src/tests/Feature/ListProjects/ListProjectsShowTest.php
@@ -27,6 +27,7 @@ class ListProjectsShowTest extends TestCase
 
         $this->projectOne = ListProjects::factory()->create([
             'id' => 1,
+            'user_id' => $this->userOne->id,
             'title' => 'Project Alpha',
             'time_duration' => '1 month',
             'language_backend' => LanguageEnum::PHP->value,
@@ -63,7 +64,10 @@ class ListProjectsShowTest extends TestCase
                 'language_frontend' => $this->projectOne->language_frontend,
                 'description' => $this->projectOne->description,
                 'roadmap' => $this->projectOne->roadmap,
-
+                'owner' => [
+                    'id' => $this->projectOne->user->id,
+                    'name' => $this->projectOne->user->name,
+                ],
                 'contributors' => [
                     [
                         'name' => $this->contributorOne->user->name,
@@ -103,6 +107,17 @@ class ListProjectsShowTest extends TestCase
             'limit_date_inscription' => $this->projectOne->limit_date_inscription,
             'dev_front_number' => $this->projectOne->dev_front_number,
             'dev_back_number' => $this->projectOne->dev_back_number,
+        ]);
+    }
+
+    public function test_show_returns_owner():void{
+        $response = $this->Get("/api/codeconnect/{$this->projectOne->id}");
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'owner' => [
+                'id' => $this->projectOne->user->id,
+                'name'=> $this->projectOne->user->name,
+            ]
         ]);
     }
 


### PR DESCRIPTION
### Objective
Return the project owner data in index() and show() endpoints

##
✘ Add user relationship to with() in index() and show()
✘ Include owner (id, name) in the response
✘ Document swagger and added tests to verify owner