### PR TITLE
367 Polished Code Connect creation form

### DIFF
--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -316,7 +316,7 @@ const FormCreate = () => {
           </label>
           <input
             id="deadline"
-            className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none border border-gray-600 focus:outline-none focus:ring-1 focus:ring-[#B91879] focus:border-[#B91879] rounded-lg py-2 px-4"
+            className="invalid:text-gray-200 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-[#B91879] focus:border-[#B91879] rounded-lg py-2 px-4"
             type="date"
             value={formData.deadline || ""}
             required
@@ -350,7 +350,7 @@ const FormCreate = () => {
             </label>
             <select
               id="unitTime"
-              className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none bg-gray-100 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-[#B91879] focus:border-[#B91879] rounded-tr-lg rounded-br-lg py-2 px-4 w-full"
+              className="bg-gray-100 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-[#B91879] focus:border-[#B91879] rounded-tr-lg rounded-br-lg py-2 px-4 w-full"
               value={formData.unitTime}
               required
               disabled={isSubmitting}
@@ -359,8 +359,12 @@ const FormCreate = () => {
               <option value="" disabled>
                 Selecciona
               </option>
-              <option value="month">Mes</option>
-              <option value="week">Setmana</option>
+              <option value="month">
+                {formData.time <= 1 ? "Mes" : "Mesos"}
+              </option>
+              <option value="week">
+                {formData.time <= 1 ? "Setmana" : "Setmanes"}
+              </option>
             </select>
           </div>
         </div>

--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -79,7 +79,6 @@ const FormCreate = () => {
       limit_date_inscription,
     } = formData;
 
-    console.log(formData);
     if (!language_frontend) {
       toast.error("Selecciona una tecnologia frontend.");
       return false;
@@ -146,6 +145,7 @@ const FormCreate = () => {
       limit_date_inscription: formData.limit_date_inscription,
     };
 
+    console.log(formPayload);
     try {
       await createCodeConnect(formPayload);
       toast.success("Code Connect publicat amb exit");
@@ -318,7 +318,7 @@ const FormCreate = () => {
             Data límit d'inscripció *
           </label>
           <input
-            id="deadline"
+            id="limit_date_inscription"
             className="invalid:text-gray-200 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-[#B91879] focus:border-[#B91879] rounded-lg py-2 px-4"
             type="date"
             value={formData.limit_date_inscription || ""}
@@ -327,7 +327,7 @@ const FormCreate = () => {
             onChange={(e) =>
               handleDeadLine("limit_date_inscription", e.target.value)
             }
-            min="2023-01-01"
+            min={getMinDeadline()}
           />
         </div>
       </div>

--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -145,7 +145,6 @@ const FormCreate = () => {
       limit_date_inscription: formData.limit_date_inscription,
     };
 
-    console.log(formPayload);
     try {
       await createCodeConnect(formPayload);
       toast.success("Code Connect publicat amb exit");

--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -1,14 +1,20 @@
-import { useState, FormEvent } from "react";
-import {
-  contentTechsFrontCodeConnect,
-  contentTechsBackCodeConnect,
-} from "./techsLabelsContent";
-import { IntCodeConnect } from "../../types";
-import { createCodeConnect } from "../../api/endPointCodeConnect";
-import { formatDocumentIcons } from "../../icons/formatDocumentIconsArray";
 import { ArrowLeftIcon } from "lucide-react";
+import { FormEvent, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { createCodeConnect } from "../../api/endPointCodeConnect";
+import { formatDocumentIcons } from "../../icons/formatDocumentIconsArray";
+import { IntCodeConnect } from "../../types";
+import {
+  contentTechsBackCodeConnect,
+  contentTechsFrontCodeConnect,
+} from "./techsLabelsContent";
+
+const getMinDeadline = () => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().split("T")[0];
+};
 
 const FormCreate = () => {
   const [formData, setFormData] = useState<IntCodeConnect>({
@@ -316,7 +322,7 @@ const FormCreate = () => {
             required
             disabled={isSubmitting}
             onChange={(e) => handleDeadLine("deadline", e.target.value)}
-            min="2023-01-01"
+            min={getMinDeadline()}
           />
         </div>
       </div>

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -130,7 +130,6 @@ describe("FormCreateCodeConnect", () => {
       });
     });
 
-    it("should only allow to set a future inscription deadline", async () => {
     it("should show error if the time duration exceeds 6 months", async () => {
       const user = userEvent.setup();
       renderWithRouter(<FormCreateCodeConnect />);
@@ -157,7 +156,7 @@ describe("FormCreateCodeConnect", () => {
       });
     });
 
-    it("should pass validation with all required fields filled correctly", async () => {
+    it("should only allow to set a future inscription deadline", async () => {
       const user = userEvent.setup();
       renderWithRouter(<FormCreateCodeConnect />);
 
@@ -176,38 +175,26 @@ describe("FormCreateCodeConnect", () => {
       await user.type(deadlineInput, "2030-01-01");
       expect(deadlineInput).toBeValid();
     });
-  });
 
-  it("should pass validation with all required fields filled correctly", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
+    it("should pass validation with all required fields filled correctly", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
 
-    await fillCompleteForm(user);
+      await fillCompleteForm(user);
 
-    const submitButton = screen.getByRole("button", { name: /publicar/i });
-    await user.click(submitButton);
+      const submitButton = screen.getByRole("button", { name: /publicar/i });
+      await user.click(submitButton);
 
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "Completa tots els camps obligatoris.",
-    );
-  });
-});
-
-describe("handleSubmit", () => {
-  it("should navigate on successful submission", async () => {
-    const user = userEvent.setup();
-
-    mockCreateCodeConnect.mockResolvedValueOnce({
-      id: "123",
-      title: "Test Project",
-      techsFront: ["React"],
-      techsBack: ["Node"],
-      description: "Test description",
-      numberDevsFront: 2,
-      numberDevsBack: 2,
-      time: 2,
-      unitTime: "month",
+      expect(toast.error).not.toHaveBeenCalledWith(
+        "Completa tots els camps obligatoris.",
+      );
     });
+  });
+
+  describe("handleSubmit", () => {
+    it("should navigate on successful submission", async () => {
+      const user = userEvent.setup();
+
       mockCreateCodeConnect.mockResolvedValueOnce({
         id: "123",
         title: "Test Project",
@@ -225,9 +212,12 @@ describe("handleSubmit", () => {
       await fillCompleteForm(user);
       expect(toast.error).not.toHaveBeenCalled();
 
-    renderWithRouter(<FormCreateCodeConnect />);
+      const form = screen
+        .getByRole("textbox", { name: /títol/i })
+        .closest("form");
+      if (!form) throw new Error("Form not found");
+      fireEvent.submit(form);
 
-    await fillCompleteForm(user);
       await waitFor(
         () => {
           expect(mockCreateCodeConnect).toHaveBeenCalled();
@@ -240,135 +230,132 @@ describe("handleSubmit", () => {
         { timeout: 3000 },
       );
 
-    expect(toast.error).not.toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith(
+        "Code Connect publicat amb exit",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+    });
 
-    const form = screen
-      .getByRole("textbox", { name: /títol/i })
-      .closest("form");
-    if (!form) throw new Error("Form not found");
-    fireEvent.submit(form);
+    it("should prevent form submission when validation fails", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
 
-    await waitFor(
-      () => {
-        expect(mockCreateCodeConnect).toHaveBeenCalled();
-      },
-      { timeout: 3000 },
-    );
+      const submitButton = screen.getByRole("button", { name: /publicar/i });
+      await user.click(submitButton);
 
-    expect(toast.success).toHaveBeenCalledWith(
-      "Code Connect publicat amb exit",
-    );
-    expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
-  it("should prevent form submission when validation fails", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
+  describe("Input handling", () => {
+    it("should update title when typing", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
 
-    const submitButton = screen.getByRole("button", { name: /publicar/i });
-    await user.click(submitButton);
+      const titleInput = screen.getByRole("textbox", {
+        name: /títol/i,
+      }) as HTMLInputElement;
 
-    expect(mockNavigate).not.toHaveBeenCalled();
+      await user.type(titleInput, "My Test Title");
+
+      expect(titleInput.value).toBe("My Test Title");
+    });
+
+    it("should update description when typing", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+
+      const descriptionTextarea = screen.getByRole("textbox", {
+        name: /descripció/i,
+      }) as HTMLTextAreaElement;
+
+      await user.type(descriptionTextarea, "My test description");
+
+      expect(descriptionTextarea.value).toBe("My test description");
+    });
+
+    it("should enforce title character limit of 65", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+
+      const titleInput = screen.getByRole("textbox", {
+        name: /títol/i,
+      }) as HTMLInputElement;
+
+      const longTitle = "a".repeat(70);
+      await user.type(titleInput, longTitle);
+
+      expect(titleInput.value.length).toBe(65);
+    });
+
+    it("should update frontend dev count when typing valid number", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+
+      const devsFrontInput = screen.getByLabelText(
+        /nombre de programadors frontend/i,
+      ) as HTMLInputElement;
+
+      await user.clear(devsFrontInput);
+      await user.type(devsFrontInput, "5");
+
+      expect(devsFrontInput.value).toBe("5");
+    });
+
+    it("should update backend dev count when typing valid number", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+
+      const devsBackInput = screen.getByLabelText(
+        /nombre de programadors backend/i,
+      ) as HTMLInputElement;
+
+      await user.clear(devsBackInput);
+      await user.type(devsBackInput, "3");
+
+      expect(devsBackInput.value).toBe("3");
+    });
   });
-});
 
-describe("Input handling", () => {
-  it("should update title when typing", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
-
-    const titleInput = screen.getByRole("textbox", {
-      name: /títol/i,
-    }) as HTMLInputElement;
-
-    await user.type(titleInput, "My Test Title");
-
-    expect(titleInput.value).toBe("My Test Title");
-  });
-
-  it("should update description when typing", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
-
-    const descriptionTextarea = screen.getByRole("textbox", {
-      name: /descripció/i,
-    }) as HTMLTextAreaElement;
-
-    await user.type(descriptionTextarea, "My test description");
-
-    expect(descriptionTextarea.value).toBe("My test description");
-  });
-
-  it("should enforce title character limit of 65", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
-
-    const titleInput = screen.getByRole("textbox", {
-      name: /títol/i,
-    }) as HTMLInputElement;
-
-    const longTitle = "a".repeat(70);
-    await user.type(titleInput, longTitle);
-
-    expect(titleInput.value.length).toBe(65);
-  });
-
-  it("should update frontend dev count when typing valid number", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
-
-    const devsFrontInput = screen.getByLabelText(
-      /nombre de programadors frontend/i,
-    ) as HTMLInputElement;
-
-    await user.clear(devsFrontInput);
-    await user.type(devsFrontInput, "5");
-
-    expect(devsFrontInput.value).toBe("5");
-  });
-
-  it("should update backend dev count when typing valid number", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
-
-    const devsBackInput = screen.getByLabelText(
-      /nombre de programadors backend/i,
-    ) as HTMLInputElement;
-
-    await user.clear(devsBackInput);
-    await user.type(devsBackInput, "3");
-
-    expect(devsBackInput.value).toBe("3");
-  });
-});
-
-describe("Navigation and UI", () => {
-  it("should navigate back to code connect when clicking back link", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
+  describe("Navigation and UI", () => {
+    it("should navigate back to code connect when clicking back link", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
       const nodeRadio = screen.getByRole("radio", { name: /node/i });
       await user.click(nodeRadio);
 
-    const backLink = screen.getByText(/tornar a code connect/i);
-    await user.click(backLink);
+      const backLink = screen.getByText(/tornar a code connect/i);
+      await user.click(backLink);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+      expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+    });
+    it("should display the time unit value options for the project duration in plural or singular depending on the time value entered previously by the user", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+      const timeInput = screen.getByLabelText(
+        /durada del projecte/i,
+      ) as HTMLInputElement;
+      const monthOption = screen.getByRole("option", { name: /mes/i });
+      const weekOption = screen.getByRole("option", { name: /setmana/i });
+      expect(monthOption).toHaveTextContent("Mes");
+      await user.clear(timeInput);
+      await user.type(timeInput, "2");
+      expect(monthOption).toHaveTextContent("Mesos");
+      expect(weekOption).toHaveTextContent("Setmanes");
+    });
   });
-  it("should display the time unit value options for the project duration in plural or singular depending on the time value entered previously by the user", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
-    const timeInput = screen.getByLabelText(
-      /durada del projecte/i,
-    ) as HTMLInputElement;
-    const monthOption = screen.getByRole("option", { name: /mes/i });
-    const weekOption = screen.getByRole("option", { name: /setmana/i });
-    expect(monthOption).toHaveTextContent("Mes");
-    await user.clear(timeInput);
-    await user.type(timeInput, "2");
-    expect(monthOption).toHaveTextContent("Mesos");
-    expect(weekOption).toHaveTextContent("Setmanes");
-  });
-});
+
+  describe("Tech selection", () => {
+    it("should show error when submitting without selecting any frontend technology", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+
+      const nodeRadio = screen.getByRole("radio", { name: /node/i });
+      await user.click(nodeRadio);
+
+      const form = document.querySelector("form")!;
+      fireEvent.submit(form);
+
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
           "Selecciona una tecnologia frontend.",
@@ -376,16 +363,15 @@ describe("Navigation and UI", () => {
       });
     });
 
-describe("Tech selection", () => {
-  it("should show error when submitting without selecting any frontend technology", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
+    it("should show error when submitting without selecting any backend technology", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
 
       const reactRadio = screen.getByRole("radio", { name: /react/i });
       await user.click(reactRadio);
 
-    const form = document.querySelector("form")!;
-    fireEvent.submit(form);
+      const form = document.querySelector("form")!;
+      fireEvent.submit(form);
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
@@ -393,41 +379,24 @@ describe("Tech selection", () => {
         );
       });
     });
-  });
 
-  it("should show error when submitting without selecting any backend technology", async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<FormCreateCodeConnect />);
+    it("should show placeholder '0' and empty value when number inputs are at default", () => {
+      renderWithRouter(<FormCreateCodeConnect />);
 
-    const reactCheckbox = screen.getByRole("checkbox", { name: /react/i });
-    await user.click(reactCheckbox);
+      const timeInput = document.getElementById("time") as HTMLInputElement;
+      const devsFrontInput = document.getElementById(
+        "devs-front",
+      ) as HTMLInputElement;
+      const devsBackInput = document.getElementById(
+        "devs-back",
+      ) as HTMLInputElement;
 
-    const form = document.querySelector("form")!;
-    fireEvent.submit(form);
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "Selecciona almenys una tecnologia backend.",
-      );
+      expect(timeInput.value).toBe("");
+      expect(timeInput.placeholder).toBe("0");
+      expect(devsFrontInput.value).toBe("");
+      expect(devsFrontInput.placeholder).toBe("0");
+      expect(devsBackInput.value).toBe("");
+      expect(devsBackInput.placeholder).toBe("0");
     });
-  });
-
-  it("should show placeholder '0' and empty value when number inputs are at default", () => {
-    renderWithRouter(<FormCreateCodeConnect />);
-
-    const timeInput = document.getElementById("time") as HTMLInputElement;
-    const devsFrontInput = document.getElementById(
-      "devs-front",
-    ) as HTMLInputElement;
-    const devsBackInput = document.getElementById(
-      "devs-back",
-    ) as HTMLInputElement;
-
-    expect(timeInput.value).toBe("");
-    expect(timeInput.placeholder).toBe("0");
-    expect(devsFrontInput.value).toBe("");
-    expect(devsFrontInput.placeholder).toBe("0");
-    expect(devsBackInput.value).toBe("");
-    expect(devsBackInput.placeholder).toBe("0");
   });
 });

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import FormCreateCodeConnect from "../FormCreate";
 import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FormCreateCodeConnect from "../FormCreate";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -58,8 +58,7 @@ const fillCompleteForm = async (user: ReturnType<typeof userEvent.setup>) => {
   const timeInput = screen.getByLabelText(
     /durada del projecte/i,
   ) as HTMLInputElement;
-  await user.tripleClick(timeInput);
-  await user.keyboard("2");
+  await user.type(timeInput, "2");
 
   const unitTimeSelect = screen.getByLabelText(/tipus durada/i);
   await user.selectOptions(unitTimeSelect, "month");
@@ -67,14 +66,12 @@ const fillCompleteForm = async (user: ReturnType<typeof userEvent.setup>) => {
   const devsFrontInput = screen.getByLabelText(
     /nombre de programadors frontend/i,
   ) as HTMLInputElement;
-  await user.tripleClick(devsFrontInput);
-  await user.keyboard("2");
+  await user.type(devsFrontInput, "2");
 
   const devsBackInput = screen.getByLabelText(
     /nombre de programadors backend/i,
   ) as HTMLInputElement;
-  await user.tripleClick(devsBackInput);
-  await user.keyboard("2");
+  await user.type(devsBackInput, "2");
 
   await waitFor(() => {
     expect(titleInput.value).toBe("Test Project");
@@ -104,207 +101,227 @@ describe("FormCreateCodeConnect", () => {
       });
     });
 
-    it("should pass validation with all required fields filled correctly", async () => {
+    it("should only allow to set a future inscription deadline", async () => {
       const user = userEvent.setup();
       renderWithRouter(<FormCreateCodeConnect />);
 
-      await fillCompleteForm(user);
+      const deadlineInput = screen.getByLabelText(
+        /data límit d'inscripció/i,
+      ) as HTMLInputElement;
 
-      const submitButton = screen.getByRole("button", { name: /publicar/i });
-      await user.click(submitButton);
+      await user.type(deadlineInput, "2025-01-01");
+      expect(deadlineInput.checkValidity()).toBe(false);
+      const now = new Date();
+      const today = now.toISOString().split("T")[0];
+      await user.clear(deadlineInput);
+      await user.type(deadlineInput, today);
+      expect(deadlineInput.checkValidity()).toBe(false);
+      await user.clear(deadlineInput);
+      await user.type(deadlineInput, "2030-01-01");
+      expect(deadlineInput.checkValidity()).toBe(true);
+    });
+  });
 
-      expect(toast.error).not.toHaveBeenCalledWith(
-        "Completa tots els camps obligatoris.",
+  it("should pass validation with all required fields filled correctly", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    await fillCompleteForm(user);
+
+    const submitButton = screen.getByRole("button", { name: /publicar/i });
+    await user.click(submitButton);
+
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "Completa tots els camps obligatoris.",
+    );
+  });
+});
+
+describe("handleSubmit", () => {
+  it("should navigate on successful submission", async () => {
+    const user = userEvent.setup();
+
+    mockCreateCodeConnect.mockResolvedValueOnce({
+      id: "123",
+      title: "Test Project",
+      techsFront: ["React"],
+      techsBack: ["Node"],
+      description: "Test description",
+      numberDevsFront: 2,
+      numberDevsBack: 2,
+      time: 2,
+      unitTime: "month",
+    });
+
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    await fillCompleteForm(user);
+
+    expect(toast.error).not.toHaveBeenCalled();
+
+    const form = screen
+      .getByRole("textbox", { name: /títol/i })
+      .closest("form");
+    if (!form) throw new Error("Form not found");
+    fireEvent.submit(form);
+
+    await waitFor(
+      () => {
+        expect(mockCreateCodeConnect).toHaveBeenCalled();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(toast.success).toHaveBeenCalledWith(
+      "Code Connect publicat amb exit",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+  });
+
+  it("should prevent form submission when validation fails", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const submitButton = screen.getByRole("button", { name: /publicar/i });
+    await user.click(submitButton);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("Input handling", () => {
+  it("should update title when typing", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const titleInput = screen.getByRole("textbox", {
+      name: /títol/i,
+    }) as HTMLInputElement;
+
+    await user.type(titleInput, "My Test Title");
+
+    expect(titleInput.value).toBe("My Test Title");
+  });
+
+  it("should update description when typing", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const descriptionTextarea = screen.getByRole("textbox", {
+      name: /descripció/i,
+    }) as HTMLTextAreaElement;
+
+    await user.type(descriptionTextarea, "My test description");
+
+    expect(descriptionTextarea.value).toBe("My test description");
+  });
+
+  it("should enforce title character limit of 65", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const titleInput = screen.getByRole("textbox", {
+      name: /títol/i,
+    }) as HTMLInputElement;
+
+    const longTitle = "a".repeat(70);
+    await user.type(titleInput, longTitle);
+
+    expect(titleInput.value.length).toBe(65);
+  });
+
+  it("should update frontend dev count when typing valid number", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const devsFrontInput = screen.getByLabelText(
+      /nombre de programadors frontend/i,
+    ) as HTMLInputElement;
+
+    await user.clear(devsFrontInput);
+    await user.type(devsFrontInput, "5");
+
+    expect(devsFrontInput.value).toBe("5");
+  });
+
+  it("should update backend dev count when typing valid number", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const devsBackInput = screen.getByLabelText(
+      /nombre de programadors backend/i,
+    ) as HTMLInputElement;
+
+    await user.clear(devsBackInput);
+    await user.type(devsBackInput, "3");
+
+    expect(devsBackInput.value).toBe("3");
+  });
+});
+
+describe("Navigation and UI", () => {
+  it("should navigate back to code connect when clicking back link", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const backLink = screen.getByText(/tornar a code connect/i);
+    await user.click(backLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+  });
+});
+
+describe("Tech selection", () => {
+  it("should show error when submitting without selecting any frontend technology", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const nodeCheckbox = screen.getByRole("checkbox", { name: /node/i });
+    await user.click(nodeCheckbox);
+
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Selecciona almenys una tecnologia frontend.",
       );
     });
   });
 
-  describe("handleSubmit", () => {
-    it("should navigate on successful submission", async () => {
-      const user = userEvent.setup();
+  it("should show error when submitting without selecting any backend technology", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
 
-      mockCreateCodeConnect.mockResolvedValueOnce({
-        id: "123",
-        title: "Test Project",
-        techsFront: ["React"],
-        techsBack: ["Node"],
-        description: "Test description",
-        numberDevsFront: 2,
-        numberDevsBack: 2,
-        time: 2,
-        unitTime: "month",
-      });
+    const reactCheckbox = screen.getByRole("checkbox", { name: /react/i });
+    await user.click(reactCheckbox);
 
-      renderWithRouter(<FormCreateCodeConnect />);
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
 
-      await fillCompleteForm(user);
-
-      expect(toast.error).not.toHaveBeenCalled();
-
-      const form = screen
-        .getByRole("textbox", { name: /títol/i })
-        .closest("form");
-      if (!form) throw new Error("Form not found");
-      fireEvent.submit(form);
-
-      await waitFor(
-        () => {
-          expect(mockCreateCodeConnect).toHaveBeenCalled();
-        },
-        { timeout: 3000 },
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Selecciona almenys una tecnologia backend.",
       );
-
-      expect(toast.success).toHaveBeenCalledWith(
-        "Code Connect publicat amb exit",
-      );
-      expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
-    });
-
-    it("should prevent form submission when validation fails", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const submitButton = screen.getByRole("button", { name: /publicar/i });
-      await user.click(submitButton);
-
-      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 
-  describe("Input handling", () => {
-    it("should update title when typing", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
+  it("should show placeholder '0' and empty value when number inputs are at default", () => {
+    renderWithRouter(<FormCreateCodeConnect />);
 
-      const titleInput = screen.getByRole("textbox", {
-        name: /títol/i,
-      }) as HTMLInputElement;
+    const timeInput = document.getElementById("time") as HTMLInputElement;
+    const devsFrontInput = document.getElementById(
+      "devs-front",
+    ) as HTMLInputElement;
+    const devsBackInput = document.getElementById(
+      "devs-back",
+    ) as HTMLInputElement;
 
-      await user.type(titleInput, "My Test Title");
-
-      expect(titleInput.value).toBe("My Test Title");
-    });
-
-    it("should update description when typing", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const descriptionTextarea = screen.getByRole("textbox", {
-        name: /descripció/i,
-      }) as HTMLTextAreaElement;
-
-      await user.type(descriptionTextarea, "My test description");
-
-      expect(descriptionTextarea.value).toBe("My test description");
-    });
-
-    it("should enforce title character limit of 65", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const titleInput = screen.getByRole("textbox", {
-        name: /títol/i,
-      }) as HTMLInputElement;
-
-      const longTitle = "a".repeat(70);
-      await user.type(titleInput, longTitle);
-
-      expect(titleInput.value.length).toBe(65);
-    });
-
-    it("should update frontend dev count when typing valid number", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const devsFrontInput = screen.getByLabelText(
-        /nombre de programadors frontend/i,
-      ) as HTMLInputElement;
-
-      await user.clear(devsFrontInput);
-      await user.type(devsFrontInput, "5");
-
-      expect(devsFrontInput.value).toBe("5");
-    });
-
-    it("should update backend dev count when typing valid number", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const devsBackInput = screen.getByLabelText(
-        /nombre de programadors backend/i,
-      ) as HTMLInputElement;
-
-      await user.clear(devsBackInput);
-      await user.type(devsBackInput, "3");
-
-      expect(devsBackInput.value).toBe("3");
-    });
-  });
-
-  describe("Navigation and UI", () => {
-    it("should navigate back to code connect when clicking back link", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const backLink = screen.getByText(/tornar a code connect/i);
-      await user.click(backLink);
-
-      expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
-    });
-  });
-
-  describe("Tech selection", () => {
-    it("should show error when submitting without selecting any frontend technology", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const nodeCheckbox = screen.getByRole("checkbox", { name: /node/i });
-      await user.click(nodeCheckbox);
-
-      const form = document.querySelector("form")!;
-      fireEvent.submit(form);
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          "Selecciona almenys una tecnologia frontend.",
-        );
-      });
-    });
-
-    it("should show error when submitting without selecting any backend technology", async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const reactCheckbox = screen.getByRole("checkbox", { name: /react/i });
-      await user.click(reactCheckbox);
-
-      const form = document.querySelector("form")!;
-      fireEvent.submit(form);
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          "Selecciona almenys una tecnologia backend.",
-        );
-      });
-    });
-
-    it("should show placeholder '0' and empty value when number inputs are at default", () => {
-      renderWithRouter(<FormCreateCodeConnect />);
-
-      const timeInput = document.getElementById("time") as HTMLInputElement;
-      const devsFrontInput = document.getElementById(
-        "devs-front",
-      ) as HTMLInputElement;
-      const devsBackInput = document.getElementById(
-        "devs-back",
-      ) as HTMLInputElement;
-
-      expect(timeInput.value).toBe("");
-      expect(timeInput.placeholder).toBe("0");
-      expect(devsFrontInput.value).toBe("");
-      expect(devsFrontInput.placeholder).toBe("0");
-      expect(devsBackInput.value).toBe("");
-      expect(devsBackInput.placeholder).toBe("0");
-    });
+    expect(timeInput.value).toBe("");
+    expect(timeInput.placeholder).toBe("0");
+    expect(devsFrontInput.value).toBe("");
+    expect(devsFrontInput.placeholder).toBe("0");
+    expect(devsBackInput.value).toBe("");
+    expect(devsBackInput.placeholder).toBe("0");
   });
 });

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
@@ -110,15 +111,15 @@ describe("FormCreateCodeConnect", () => {
       ) as HTMLInputElement;
 
       await user.type(deadlineInput, "2025-01-01");
-      expect(deadlineInput.checkValidity()).toBe(false);
+      expect(deadlineInput).toBeInvalid();
       const now = new Date();
       const today = now.toISOString().split("T")[0];
       await user.clear(deadlineInput);
       await user.type(deadlineInput, today);
-      expect(deadlineInput.checkValidity()).toBe(false);
+      expect(deadlineInput).toBeInvalid();
       await user.clear(deadlineInput);
       await user.type(deadlineInput, "2030-01-01");
-      expect(deadlineInput.checkValidity()).toBe(true);
+      expect(deadlineInput).toBeValid();
     });
   });
 
@@ -268,6 +269,20 @@ describe("Navigation and UI", () => {
     await user.click(backLink);
 
     expect(mockNavigate).toHaveBeenCalledWith("/codeconnect");
+  });
+  it("should display the time unit value options for the project duration in plural or singular depending on the time value entered previously by the user", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+    const timeInput = screen.getByLabelText(
+      /durada del projecte/i,
+    ) as HTMLInputElement;
+    const monthOption = screen.getByRole("option", { name: /mes/i });
+    const weekOption = screen.getByRole("option", { name: /setmana/i });
+    expect(monthOption).toHaveTextContent("Mes");
+    await user.clear(timeInput);
+    await user.type(timeInput, "2");
+    expect(monthOption).toHaveTextContent("Mesos");
+    expect(weekOption).toHaveTextContent("Setmanes");
   });
 });
 


### PR DESCRIPTION
### Finished polishing the Code Connect creation form

- When date unset, the default today's date displayed in the input[type="date] field now looks like a placeholder, so it's easier for the user not to skip it before attempting submission:
<img width="608" height="82" alt="Capture d’écran 2026-04-28 à 14 22 32" src="https://github.com/user-attachments/assets/fd83cde0-54f3-4951-be2f-c596016c6f57" />


- Update the input's min harcoded date value to a dynamic one so the user can never select a past or today' date:
<img width="670" height="221" alt="Capture d’écran 2026-04-28 à 14 29 43" src="https://github.com/user-attachments/assets/cb61d9f2-f0c4-4f8e-871c-f1df2125803f" />


- Testing:  Updated FormCreate.test.tsx accordingly

NB: since that literally was a 10 seconds fix and the only remaining pending improvement to do on the form (at least for now), I also implemented dynamic value for the time duration unit dropdown so it shows the value in plural or singular depending on the number entered by the user in the previous input:
<table>
  <tr>
    <td align="center">
<img width="524" height="116" alt="Capture d’écran 2026-04-28 à 14 32 53" src="https://github.com/user-attachments/assets/6faee0fc-6fe9-4052-9e34-19ea7740c37d" />
    </td>
    <td align="center">
<img width="571" height="115" alt="Capture d’écran 2026-04-28 à 14 33 02" src="https://github.com/user-attachments/assets/cec43a15-e127-4087-8795-e2128f0facb8" />
    </td>
  </tr>