### PR TITLE
Feature/liga store endpoints

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -12,7 +12,7 @@ class LigaController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-        'user_id' => 'required|integer|exists:user,id',
+        'user_id' => 'required|integer|exists:users,id',
         ]);
 
         if (Liga::where('user_id', $validated['user_id'])->exists()) {

--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -44,10 +44,5 @@ class LigaController extends Controller
     {
         return response()->json(['user_id' => $user->id, 'points' => 99]);
     }
-
-    public function store(Request $request)
-    {
-        return response()->json(['message' => 'created'], 201);
-    }
 }
 

--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Liga;
+use Illuminate\Http\Request;
+
+class LigaController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+        'user_id' => 'required|integer|exists:user,id',
+        ]);
+
+        if (Liga::where('user_id', $validated['user_id'])->exists()) {
+            return response()->json(['error' => 'Entry already exists for this user'], 409);
+        }
+
+         $entry = Liga::create(['user_id' => $validated['user_id'], 'points' => 0]);
+
+        return response()->json($entry, 201);
+    }
+}
+
+

--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-
 use App\Models\Liga;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -15,14 +14,14 @@ class LigaController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-        'user_id' => 'required|integer|exists:users,id',
+            'user_id' => 'required|integer|exists:users,id',
         ]);
 
         if (Liga::where('user_id', $validated['user_id'])->exists()) {
             return response()->json(['error' => 'Entry already exists for this user'], 409);
         }
 
-         $entry = Liga::create(['user_id' => $validated['user_id'], 'points' => 0]);
+        $entry = Liga::create(['user_id' => $validated['user_id'], 'points' => 0]);
 
         return response()->json($entry, 201);
     }

--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Liga extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'points',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Tickets\TicketController;
 use App\Http\Controllers\Tickets\TicketCommentController;
 use Illuminate\Http\Request;
 use App\Http\Controllers\FeatureFlagController;
+use App\Http\Controllers\LigaController;
 
 // GitHub Auth System Endpoints (PUBLIC)
 Route::get('/auth/github/redirect', [GitHubAuthController::class, 'redirect'])->name('github.redirect');
@@ -168,6 +169,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::put('tickets/{ticket}/comments/{comment}', [TicketCommentController::class, 'update'])->name('tickets.comments.update');
     Route::delete('tickets/{ticket}/comments/{comment}', [TicketCommentController::class, 'destroy'])->name('tickets.comments.destroy');
 });
+
+// ========== LIGA ENDPOINTS ==========
+Route::post('/ligas', [LigaController::class, 'store'])->name('ligas.store');
 
 
 

--- a/backend/src/tests/Feature/LigaTests/LigaStoreLigaTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaStoreLigaTest.php
@@ -34,6 +34,7 @@ class LigaStoreLigaTest extends TestCase
         $response = $this->postJson('/api/ligas', ['user_id' => $user->id]);
 
         $response->assertStatus(409);
+        $response->assertJson(['error' => 'Entry already exists for this user']);
     }
 
     public function test_store_returns_422_when_user_id_is_missing(): void

--- a/backend/src/tests/Feature/LigaTests/LigaStoreLigaTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaStoreLigaTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\LigaTests;
+
+use Tests\TestCase;
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class LigaStoreLigaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_creates_liga_entry_with_zero_points(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/ligas', ['user_id' => $user->id]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('ligas', [
+            'user_id' => $user->id,
+            'points'  => 0,
+        ]);
+    }
+
+    public function test_store_returns_409_if_entry_already_exists(): void
+    {
+        $user = User::factory()->create();
+        Liga::create(['user_id' => $user->id, 'points' => 0]);
+
+        $response = $this->postJson('/api/ligas', ['user_id' => $user->id]);
+
+        $response->assertStatus(409);
+    }
+
+    public function test_store_returns_422_when_user_id_is_missing(): void
+    {
+        $response = $this->postJson('/api/ligas', []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_store_returns_422_when_user_does_not_exist(): void
+    {
+        $response = $this->postJson('/api/ligas', ['user_id' => 99999]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
Implements the POST /api/ligas endpoint that creates a new Liga entry for a user with a starting score of zero.

## Changes
- `Liga.php` — minimal model with fillable fields
- `LigaController.php` — store() method with validation and 409 conflict check
- `api.php` — POST /ligas route registered
- `LigaStoreLigaTest.php` — 4 test cases covering 201, 409, and 422 responses

## Important
`Liga.php` and `LigaController.php` have been created intentionally in this PR to avoid a dependency on `feature/liga-endpoints-stub` and `feature/liga-factory-seeder`. This will generate merge conflicts when those branches are integrated into develop. The conflicts are expected and will be resolved at merge time, replacing these temporary files with the full implementations.


