### PR TITLE
Feature/404 allow assignee to close assigned tickets

### DIFF
--- a/backend/src/app/Http/Controllers/Tickets/TicketCommentController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketCommentController.php
@@ -31,20 +31,12 @@ class TicketCommentController extends Controller
 
         $isClosingComment = $request->validated()['is_closing_comment'] ?? false;
 
-        $isCreator  = (int) $ticket->code_connect_id === (int) $user->id;
-        $isAssignee = (int) $ticket->assignee_id     === (int) $user->id;
-
-        if ($isClosingComment
-            && !$user->hasAnyRole(['admin', 'superadmin'])
-            && !$isCreator
-            && !$isAssignee
-        ) {
+        if ($isClosingComment && !$ticket->canClose($user)) {
             return response()->json([
                 'success' => false,
                 'message' => 'Unauthorized to close this ticket',
             ], 403);
         }
-
 
         $comment = $ticket->comments()->create([
             'user_id' => $request->user()->id,

--- a/backend/src/app/Http/Controllers/Tickets/TicketCommentController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketCommentController.php
@@ -31,15 +31,20 @@ class TicketCommentController extends Controller
 
         $isClosingComment = $request->validated()['is_closing_comment'] ?? false;
 
+        $isCreator  = (int) $ticket->code_connect_id === (int) $user->id;
+        $isAssignee = (int) $ticket->assignee_id     === (int) $user->id;
+
         if ($isClosingComment
             && !$user->hasAnyRole(['admin', 'superadmin'])
-            && $ticket->code_connect_id !== $user->id
+            && !$isCreator
+            && !$isAssignee
         ) {
             return response()->json([
                 'success' => false,
                 'message' => 'Unauthorized to close this ticket',
             ], 403);
         }
+
 
         $comment = $ticket->comments()->create([
             'user_id' => $request->user()->id,

--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -96,15 +96,20 @@ class TicketController extends Controller
         $user = auth()->user();
         $status = $request->validated()['status'];
 
+        $isCreator  = (int) $ticket->code_connect_id === (int) $user->id;
+        $isAssignee = (int) $ticket->assignee_id     === (int) $user->id;
+
         if ($status === 'closed'
             && !$user->hasAnyRole(['admin', 'superadmin'])
-            && $ticket->code_connect_id !== $user->id
+            && !$isCreator
+            && !$isAssignee
         ) {
             return response()->json([
                 'success' => false,
                 'message' => 'Unauthorized to close this ticket',
             ], 403);
         }
+
 
         $updateData = ['status' => $status];
 

--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -96,20 +96,12 @@ class TicketController extends Controller
         $user = auth()->user();
         $status = $request->validated()['status'];
 
-        $isCreator  = (int) $ticket->code_connect_id === (int) $user->id;
-        $isAssignee = (int) $ticket->assignee_id     === (int) $user->id;
-
-        if ($status === 'closed'
-            && !$user->hasAnyRole(['admin', 'superadmin'])
-            && !$isCreator
-            && !$isAssignee
-        ) {
+        if ($status === 'closed' && !$ticket->canClose($user)) {
             return response()->json([
                 'success' => false,
                 'message' => 'Unauthorized to close this ticket',
             ], 403);
         }
-
 
         $updateData = ['status' => $status];
 
@@ -126,6 +118,7 @@ class TicketController extends Controller
             'data' => $ticket->fresh(['codeConnect', 'assignee', 'closedBy'])
         ], 200);
     }
+
 
     public function updatePriority(UpdatePriorityRequest $request, $id): JsonResponse{
 

--- a/backend/src/app/Models/Ticket.php
+++ b/backend/src/app/Models/Ticket.php
@@ -69,4 +69,12 @@ class Ticket extends Model
         return $this->belongsTo(ForumAnswer::class, 'forum_answer_id');
     }
     
+    public function canClose(User $user): bool
+    {
+        if ($user->hasAnyRole(['admin', 'superadmin'])) return true;
+        if ((int) $this->code_connect_id === (int) $user->id) return true;
+        if ($this->assignee_id !== null && (int) $this->assignee_id === (int) $user->id) return true;
+        return false;
+    }
+
 }

--- a/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
@@ -649,6 +649,48 @@ class TicketControllerTest extends TestCase{
         $this->assertDatabaseHas('tickets', ['id' => $ticket->id, 'status' => 'in_progress']);
     }
 
+    /** @test */
+    public function assignee_can_close_assigned_ticket_via_status_update(): void
+    {
+        $assignee = $this->authenticateUserWithRole('mentor');
+        $creator  = User::factory()->create();
+        $ticket   = Ticket::factory()->create([
+            'code_connect_id' => $creator->id,
+            'assignee_id'     => $assignee->id,
+        ]);
+
+        $response = $this->patchJson("/api/tickets/{$ticket->id}/status", [
+            'status' => 'closed'
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('tickets', [
+            'id'     => $ticket->id,
+            'status' => 'closed',
+        ]);
+    }
+
+    /** @test */
+    public function assignee_can_close_assigned_ticket_via_closing_comment(): void
+    {
+        $assignee = $this->authenticateUserWithRole('mentor');
+        $creator  = User::factory()->create();
+        $ticket   = Ticket::factory()->create([
+            'code_connect_id' => $creator->id,
+            'assignee_id'     => $assignee->id,
+        ]);
+
+        $response = $this->postJson("/api/tickets/{$ticket->id}/comments", [
+            'comment'            => 'Closing the ticket.',
+            'is_closing_comment' => true,
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('tickets', [
+            'id'     => $ticket->id,
+            'status' => 'closed',
+        ]);
+    }
 }
 
 ?>

--- a/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
@@ -691,6 +691,24 @@ class TicketControllerTest extends TestCase{
             'status' => 'closed',
         ]);
     }
+
+    /** @test */
+    public function non_assignee_non_creator_cannot_close_ticket(): void
+    {
+        $this->authenticateUserWithRole('student');
+        $creator  = User::factory()->create();
+        $assignee = User::factory()->create();
+        $ticket   = Ticket::factory()->create([
+            'code_connect_id' => $creator->id,
+            'assignee_id'     => $assignee->id,
+        ]);
+
+        $response = $this->patchJson("/api/tickets/{$ticket->id}/status", [
+            'status' => 'closed'
+        ]);
+
+        $response->assertStatus(403);
+    }
 }
 
 ?>


### PR DESCRIPTION
Problem

The assignee was already treated as an owner for viewing, editing and deleting tickets, but the closing logic in updateStatus and TicketCommentController::store only checked for the ticket creator. This caused the assignee to receive a 403 Forbidden when attempting to close a ticket assigned to them, making the reject button non-functional for any assignee who was not also the ticket creator.

Solution

Extended the closing permission check in both updateStatus and TicketCommentController::store to allow the assignee to close their assigned tickets, in the same way they are already allowed to perform other ownership actions. This unblocks the reject button implementation in #402.