### PR TITLE
Added "Other" chip to the front and tech language options

### DIFF
--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -227,7 +227,7 @@ const FormCreate = () => {
               >
                 <input
                   type="radio"
-                  name="language_frontend[]"
+                  name="language_frontend"
                   value={item.label}
                   checked={isSelected}
                   onChange={() =>
@@ -235,7 +235,7 @@ const FormCreate = () => {
                   }
                   className="sr-only"
                 />
-                <IconComponent className="w-5 h-5" />
+                {IconComponent ? <IconComponent className="w-5 h-5" /> : null}
                 <span className="text-sm font-medium">{item.label}</span>
               </label>
             );
@@ -261,7 +261,7 @@ const FormCreate = () => {
               >
                 <input
                   type="radio"
-                  name="language_backend[]"
+                  name="language_backend"
                   value={item.label}
                   checked={isSelected}
                   onChange={() =>
@@ -269,7 +269,7 @@ const FormCreate = () => {
                   }
                   className="sr-only"
                 />
-                <IconComponent className="w-5 h-5" />
+                {IconComponent ? <IconComponent className="w-5 h-5" /> : null}
                 <span className="text-sm font-medium">{item.label}</span>
               </label>
             );

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -8,6 +8,7 @@ import FormCreateCodeConnect from "../FormCreate";
 import {
   contentTechsBackCodeConnect,
   contentTechsFrontCodeConnect,
+  TechnologyItem,
 } from "../techsLabelsContent";
 
 vi.mock("sonner", () => ({
@@ -114,6 +115,19 @@ const fillCompleteForm = async (user: ReturnType<typeof userEvent.setup>) => {
     expect(timeInput.value).toBe("2");
     expect((unitTimeSelect as HTMLSelectElement).value).toBe("month");
     expect(deadlineInput.value).toBe("2025-11-20");
+  });
+};
+
+const checkTechOptionsRender = (language: string, list: TechnologyItem[]) => {
+  const inputs = screen
+    .getAllByRole("radio")
+    .filter((radio) => radio.getAttribute("name") === language);
+  expect(inputs).toHaveLength(list.length);
+  list.forEach((tech) => {
+    if (tech.icon) {
+      const label = screen.getByDisplayValue(tech.label).closest("label")!;
+      expect(label.querySelector("svg")).toBeInTheDocument();
+    }
   });
 };
 
@@ -387,31 +401,23 @@ describe("FormCreateCodeConnect", () => {
 
     it("should show all the technologies with their icons when available", () => {
       renderWithRouter(<FormCreateCodeConnect />);
-      const frontInputs = screen
-        .getAllByRole("radio")
-        .filter((radio) => radio.getAttribute("name") === "language_frontend");
-      expect(frontInputs).toHaveLength(contentTechsFrontCodeConnect.length);
-      const backInputs = screen
-        .getAllByRole("radio")
-        .filter((radio) => radio.getAttribute("name") === "language_backend");
-      expect(backInputs).toHaveLength(contentTechsBackCodeConnect.length);
-      contentTechsFrontCodeConnect.forEach((tech) => {
-        if (tech.icon) {
-          const label = screen.getByDisplayValue(tech.label).closest("label")!;
-          expect(label.querySelector("svg")).toBeInTheDocument();
-        }
-      });
-      contentTechsBackCodeConnect.forEach((tech) => {
-        if (tech.icon) {
-          const label = screen.getByDisplayValue(tech.label).closest("label")!;
-          expect(label.querySelector("svg")).toBeInTheDocument();
-        }
-      });
+      checkTechOptionsRender("language_frontend", contentTechsFrontCodeConnect);
+      checkTechOptionsRender("language_backend", contentTechsBackCodeConnect);
+    });
+
+    it("should select the correct technology onclick", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<FormCreateCodeConnect />);
+      const reactRadio = screen.getByRole("radio", { name: /react/i });
+      await user.click(reactRadio);
+      expect(reactRadio).toBeChecked();
+      expect(reactRadio).toHaveAttribute("value", "React");
+      const form = reactRadio.closest("form");
+      expect(form).toHaveFormValues({ language_frontend: "React" });
     });
 
     it("should show placeholder '0' and empty value when number inputs are at default", () => {
       renderWithRouter(<FormCreateCodeConnect />);
-
       const timeInput = document.getElementById("time") as HTMLInputElement;
       const devsFrontInput = document.getElementById(
         "devs-front",

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -1,9 +1,14 @@
+import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FormCreateCodeConnect from "../FormCreate";
+import {
+  contentTechsBackCodeConnect,
+  contentTechsFrontCodeConnect,
+} from "../techsLabelsContent";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -340,6 +345,30 @@ describe("FormCreateCodeConnect", () => {
         expect(toast.error).toHaveBeenCalledWith(
           "Selecciona una tecnologia backend.",
         );
+      });
+    });
+
+    it("should show all the technologies with their icons when available", () => {
+      renderWithRouter(<FormCreateCodeConnect />);
+      const frontInputs = screen
+        .getAllByRole("radio")
+        .filter((radio) => radio.getAttribute("name") === "language_frontend");
+      expect(frontInputs).toHaveLength(contentTechsFrontCodeConnect.length);
+      const backInputs = screen
+        .getAllByRole("radio")
+        .filter((radio) => radio.getAttribute("name") === "language_backend");
+      expect(backInputs).toHaveLength(contentTechsBackCodeConnect.length);
+      contentTechsFrontCodeConnect.forEach((tech) => {
+        if (tech.icon) {
+          const label = screen.getByDisplayValue(tech.label).closest("label")!;
+          expect(label.querySelector("svg")).toBeInTheDocument();
+        }
+      });
+      contentTechsBackCodeConnect.forEach((tech) => {
+        if (tech.icon) {
+          const label = screen.getByDisplayValue(tech.label).closest("label")!;
+          expect(label.querySelector("svg")).toBeInTheDocument();
+        }
       });
     });
 

--- a/frontend/src/components/code-connect/__test__/techsLabelsContent.test.ts
+++ b/frontend/src/components/code-connect/__test__/techsLabelsContent.test.ts
@@ -1,7 +1,8 @@
-import { describe, test, expect } from "vitest";
+import { describe, expect, test } from "vitest";
 import {
-  contentTechsFrontCodeConnect,
   contentTechsBackCodeConnect,
+  contentTechsFrontCodeConnect,
+  TechnologyItem,
 } from "../techsLabelsContent";
 
 const frontIconLabelMap = [
@@ -10,6 +11,7 @@ const frontIconLabelMap = [
   { label: "Svelte", iconName: "svelte_vector" },
   { label: "Vue", iconName: "vue_vector" },
   { label: "JavaScript", iconName: "js_vector" },
+  { label: "Other" },
 ];
 
 const backIconLabelMap = [
@@ -18,58 +20,44 @@ const backIconLabelMap = [
   { label: "Java", iconName: "java_vector" },
   { label: "Python", iconName: "python_vector" },
   { label: "SQL", iconName: "sql_vector" },
+  { label: "Other" },
 ];
 
-describe("contentTechsFrontCodeConnect Tests", () => {
-  test("verifies each frontend technology has the correct icon assigned", () => {
-    frontIconLabelMap.forEach(({ label, iconName }, index) => {
-      expect(contentTechsFrontCodeConnect[index].label).toBe(label);
-
-      expect(typeof contentTechsFrontCodeConnect[index].icon).toBe("function");
-
-      expect(
-        contentTechsFrontCodeConnect[index].icon,
-        `${label} should use ${iconName} icon`,
-      ).toBeDefined();
+const checkTechsLabels = (
+  contentTech: TechnologyItem[],
+  map: typeof frontIconLabelMap | typeof backIconLabelMap,
+) => {
+  test("verifies each technology has the correct icon assigned", () => {
+    map.forEach(({ label, iconName }, index) => {
+      expect(contentTech[index].label).toBe(label);
+      if (iconName) {
+        expect(typeof contentTech[index].icon).toBe("function");
+        expect(
+          contentTech[index].icon,
+          `${label} should use ${iconName} icon`,
+        ).toBeDefined();
+      } else {
+        expect(contentTech[index].icon).toBeUndefined();
+      }
     });
   });
 
   test("has correct length and all items have required properties", () => {
-    expect(contentTechsFrontCodeConnect).toHaveLength(frontIconLabelMap.length);
+    expect(contentTech).toHaveLength(map.length);
 
-    contentTechsFrontCodeConnect.forEach((item) => {
-      expect(item).toHaveProperty("icon");
+    contentTech.forEach((item) => {
       expect(item).toHaveProperty("label");
-      expect(typeof item.icon).toBe("function");
       expect(typeof item.label).toBe("string");
       expect(item.label.length).toBeGreaterThan(0);
+      if (item.icon) expect(typeof item.icon).toBe("function");
     });
   });
+};
+
+describe("contentTechsFrontCodeConnect Tests", () => {
+  checkTechsLabels(contentTechsFrontCodeConnect, frontIconLabelMap);
 });
 
 describe("contentTechsBackCodeConnect Tests", () => {
-  test("verifies each backend technology has the correct icon assigned", () => {
-    backIconLabelMap.forEach(({ label, iconName }, index) => {
-      expect(contentTechsBackCodeConnect[index].label).toBe(label);
-
-      expect(typeof contentTechsBackCodeConnect[index].icon).toBe("function");
-
-      expect(
-        contentTechsBackCodeConnect[index].icon,
-        `${label} should use ${iconName} icon`,
-      ).toBeDefined();
-    });
-  });
-
-  test("has correct length and all items have required properties", () => {
-    expect(contentTechsBackCodeConnect).toHaveLength(backIconLabelMap.length);
-
-    contentTechsBackCodeConnect.forEach((item) => {
-      expect(item).toHaveProperty("icon");
-      expect(item).toHaveProperty("label");
-      expect(typeof item.icon).toBe("function");
-      expect(typeof item.label).toBe("string");
-      expect(item.label.length).toBeGreaterThan(0);
-    });
-  });
+  checkTechsLabels(contentTechsBackCodeConnect, backIconLabelMap);
 });

--- a/frontend/src/components/code-connect/__test__/techsLabelsContent.test.ts
+++ b/frontend/src/components/code-connect/__test__/techsLabelsContent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   contentTechsBackCodeConnect,
   contentTechsFrontCodeConnect,
-  TechnologyItem,
+  type TechnologyItem,
 } from "../techsLabelsContent";
 
 const frontIconLabelMap = [

--- a/frontend/src/components/code-connect/techsLabelsContent.ts
+++ b/frontend/src/components/code-connect/techsLabelsContent.ts
@@ -13,7 +13,7 @@ import vue_logo from "../../assets/technologies/vue-logo.svg?react";
 
 type SvgIcon = FC<SVGProps<SVGSVGElement>>;
 
-type TechnologyItem = {
+export type TechnologyItem = {
   icon?: SvgIcon;
   label: string;
 };

--- a/frontend/src/components/code-connect/techsLabelsContent.ts
+++ b/frontend/src/components/code-connect/techsLabelsContent.ts
@@ -1,20 +1,20 @@
 import { FC, SVGProps } from "react";
 
-import react_logo from "../../assets/technologies/react-logo.svg?react";
 import angular_logo from "../../assets/technologies/angular-logo.svg?react";
+import java_logo from "../../assets/technologies/java-logo.svg?react";
 import javascript_logo from "../../assets/technologies/javascript-logo.svg?react";
-import svelte_logo from "../../assets/technologies/svelte-logo.svg?react";
-import vue_logo from "../../assets/technologies/vue-logo.svg?react";
 import node_logo from "../../assets/technologies/node-logo.svg?react";
 import php_logo from "../../assets/technologies/php-logo.svg?react";
-import java_logo from "../../assets/technologies/java-logo.svg?react";
 import python_logo from "../../assets/technologies/python-logo.svg?react";
+import react_logo from "../../assets/technologies/react-logo.svg?react";
 import sql_logo from "../../assets/technologies/sql-logo.svg?react";
+import svelte_logo from "../../assets/technologies/svelte-logo.svg?react";
+import vue_logo from "../../assets/technologies/vue-logo.svg?react";
 
 type SvgIcon = FC<SVGProps<SVGSVGElement>>;
 
 type TechnologyItem = {
-  icon: SvgIcon;
+  icon?: SvgIcon;
   label: string;
 };
 
@@ -24,6 +24,7 @@ export const contentTechsFrontCodeConnect: TechnologyItem[] = [
   { icon: svelte_logo, label: "Svelte" },
   { icon: vue_logo, label: "Vue" },
   { icon: javascript_logo, label: "JavaScript" },
+  { label: "Other" },
 ];
 
 export const contentTechsBackCodeConnect: TechnologyItem[] = [
@@ -32,4 +33,5 @@ export const contentTechsBackCodeConnect: TechnologyItem[] = [
   { icon: java_logo, label: "Java" },
   { icon: python_logo, label: "Python" },
   { icon: sql_logo, label: "SQL" },
+  { label: "Other" },
 ];


### PR DESCRIPTION
**Change:** the user can now chose "other" to create a project with a different language than the ones suggested
<img width="1052" height="487" alt="Capture d’écran 2026-04-29 à 13 25 24" src="https://github.com/user-attachments/assets/2bf9729d-d6cc-4a9a-9ac2-d5c84646e315" />

**Testing:** added one test in the FormCreate test file to confirm correct display of all the chips and their icon when applicable + readapted existing tests for the `contentTechsFrontCodeConnect `and `contentTechsBackCodeConnect` arrays.