### PR TITLE
#397 feat(ticketing): add useCreateTicketing hook with types, endpoint stub and tests

### DIFF
--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,5 +1,6 @@
 import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const createTicket = async (
   _data: IntCreateTicket,
 ): Promise<IntTicket> => {

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,5 +1,7 @@
 import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
 
-export const createTicket = async (_data: IntCreateTicket): Promise<IntTicket> => {
+export const createTicket = async (
+  _data: IntCreateTicket,
+): Promise<IntTicket> => {
   throw new Error("Not implemented");
 };

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,7 +1,7 @@
 import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const createTicket = async (
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _data: IntCreateTicket,
 ): Promise<IntTicket> => {
   throw new Error("Not implemented");

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -1,0 +1,5 @@
+import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
+
+export const createTicket = async (_data: IntCreateTicket): Promise<IntTicket> => {
+  throw new Error("Not implemented");
+};

--- a/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
+++ b/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
@@ -60,7 +60,10 @@ describe("useCreateTicketing", () => {
   it("should set isLoading to true during the request", async () => {
     let resolvePromise!: (value: IntTicket) => void;
     mockCreateTicket.mockImplementation(
-      () => new Promise((res) => { resolvePromise = res; }),
+      () =>
+        new Promise((res) => {
+          resolvePromise = res;
+        }),
     );
 
     const { result } = renderHook(() => useCreateTicketing());
@@ -79,13 +82,17 @@ describe("useCreateTicketing", () => {
   });
 
   it("should set error on failure and reset it on next success", async () => {
-    mockCreateTicket.mockRejectedValueOnce(new Error("Error 500: Internal Server Error"));
+    mockCreateTicket.mockRejectedValueOnce(
+      new Error("Error 500: Internal Server Error"),
+    );
     const { result } = renderHook(() => useCreateTicketing());
 
     void result.current.submitTicketing(mockTicketData);
 
     await waitFor(() => {
-      expect(result.current.error?.message).toBe("Error 500: Internal Server Error");
+      expect(result.current.error?.message).toBe(
+        "Error 500: Internal Server Error",
+      );
     });
 
     expect(result.current.ticketing).toBeNull();

--- a/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
+++ b/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
@@ -41,7 +41,7 @@ describe("useCreateTicketing", () => {
     mockCreateTicket.mockResolvedValue(mockTicketResponse);
     const { result } = renderHook(() => useCreateTicketing());
 
-    expect(result.current.ticketing).toBeNull();
+    expect(result.current.ticketing).toEqual([]);
     expect(result.current.error).toBeNull();
     expect(result.current.isLoading).toBe(false);
 
@@ -51,7 +51,7 @@ describe("useCreateTicketing", () => {
     });
 
     expect(mockCreateTicket).toHaveBeenCalledWith(mockTicketData);
-    expect(result.current.ticketing).toEqual(mockTicketResponse);
+    expect(result.current.ticketing).toEqual([mockTicketResponse]);
     expect(returned).toEqual(mockTicketResponse);
     expect(result.current.error).toBeNull();
     expect(result.current.isLoading).toBe(false);
@@ -95,7 +95,7 @@ describe("useCreateTicketing", () => {
       );
     });
 
-    expect(result.current.ticketing).toBeNull();
+    expect(result.current.ticketing).toEqual([]);
     expect(result.current.isLoading).toBe(false);
 
     mockCreateTicket.mockResolvedValueOnce(mockTicketResponse);
@@ -105,6 +105,6 @@ describe("useCreateTicketing", () => {
     });
 
     expect(result.current.error).toBeNull();
-    expect(result.current.ticketing).toEqual(mockTicketResponse);
+    expect(result.current.ticketing).toEqual([mockTicketResponse]);
   });
 });

--- a/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
+++ b/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useCreateTicketing } from "../useCreateTicketing";
+import { IntCreateTicket, IntTicket } from "../../types/ticketingTypes";
+
+const { mockCreateTicket } = vi.hoisted(() => ({
+  mockCreateTicket: vi.fn(),
+}));
+
+vi.mock("../../api/endPointTickets", () => ({
+  createTicket: mockCreateTicket,
+}));
+
+const mockTicketData: IntCreateTicket = {
+  name: "Login fails on mobile",
+  incident_date: "2026-04-29",
+  affected_app: "wiki_frontend",
+  type: "error",
+  affected_function: "login",
+  description: "The login button does not respond on mobile devices.",
+};
+
+const mockTicketResponse: IntTicket = {
+  ...mockTicketData,
+  id: 1,
+  code_connect_id: 42,
+  status: "pending",
+  priority: "medium",
+  closed_by: null,
+  closed_at: null,
+  created_at: "2026-04-29T10:00:00Z",
+  updated_at: "2026-04-29T10:00:00Z",
+};
+
+describe("useCreateTicketing", () => {
+  beforeEach(() => {
+    mockCreateTicket.mockClear();
+  });
+
+  it("should initialize with empty state and resolve successfully", async () => {
+    mockCreateTicket.mockResolvedValue(mockTicketResponse);
+    const { result } = renderHook(() => useCreateTicketing());
+
+    expect(result.current.ticketing).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+
+    let returned: IntTicket | null = null;
+    await act(async () => {
+      returned = await result.current.submitTicketing(mockTicketData);
+    });
+
+    expect(mockCreateTicket).toHaveBeenCalledWith(mockTicketData);
+    expect(result.current.ticketing).toEqual(mockTicketResponse);
+    expect(returned).toEqual(mockTicketResponse);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should set isLoading to true during the request", async () => {
+    let resolvePromise!: (value: IntTicket) => void;
+    mockCreateTicket.mockImplementation(
+      () => new Promise((res) => { resolvePromise = res; }),
+    );
+
+    const { result } = renderHook(() => useCreateTicketing());
+
+    act(() => {
+      result.current.submitTicketing(mockTicketData);
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolvePromise(mockTicketResponse);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should set error on failure and reset it on next success", async () => {
+    mockCreateTicket.mockRejectedValueOnce(new Error("Error 500: Internal Server Error"));
+    const { result } = renderHook(() => useCreateTicketing());
+
+    void result.current.submitTicketing(mockTicketData);
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("Error 500: Internal Server Error");
+    });
+
+    expect(result.current.ticketing).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+
+    mockCreateTicket.mockResolvedValueOnce(mockTicketResponse);
+
+    await act(async () => {
+      await result.current.submitTicketing(mockTicketData);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.ticketing).toEqual(mockTicketResponse);
+  });
+});

--- a/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
+++ b/frontend/src/hooks/__tests__/useCreateTicketing.test.ts
@@ -37,13 +37,17 @@ describe("useCreateTicketing", () => {
     mockCreateTicket.mockClear();
   });
 
-  it("should initialize with empty state and resolve successfully", async () => {
-    mockCreateTicket.mockResolvedValue(mockTicketResponse);
+  it("should initialize with empty state", () => {
     const { result } = renderHook(() => useCreateTicketing());
 
     expect(result.current.ticketing).toEqual([]);
     expect(result.current.error).toBeNull();
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should resolve successfully", async () => {
+    mockCreateTicket.mockResolvedValue(mockTicketResponse);
+    const { result } = renderHook(() => useCreateTicketing());
 
     let returned: IntTicket | null = null;
     await act(async () => {
@@ -81,7 +85,7 @@ describe("useCreateTicketing", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it("should set error on failure and reset it on next success", async () => {
+  it("should set error on failure", async () => {
     mockCreateTicket.mockRejectedValueOnce(
       new Error("Error 500: Internal Server Error"),
     );
@@ -97,6 +101,19 @@ describe("useCreateTicketing", () => {
 
     expect(result.current.ticketing).toEqual([]);
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should reset error on next success", async () => {
+    mockCreateTicket.mockRejectedValueOnce(
+      new Error("Error 500: Internal Server Error"),
+    );
+    const { result } = renderHook(() => useCreateTicketing());
+
+    void result.current.submitTicketing(mockTicketData);
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
 
     mockCreateTicket.mockResolvedValueOnce(mockTicketResponse);
 

--- a/frontend/src/hooks/useCreateTicketing.ts
+++ b/frontend/src/hooks/useCreateTicketing.ts
@@ -2,13 +2,14 @@ import { useState } from "react";
 import { createTicket } from "../api/endPointTickets";
 import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
 
-
 export const useCreateTicketing = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [ticketing, setTicketing] = useState<IntTicket | null>(null);
 
-  const submitTicketing = async (ticketData: IntCreateTicket): Promise<IntTicket | null> => {
+  const submitTicketing = async (
+    ticketData: IntCreateTicket,
+  ): Promise<IntTicket | null> => {
     setIsLoading(true);
     setError(null);
 

--- a/frontend/src/hooks/useCreateTicketing.ts
+++ b/frontend/src/hooks/useCreateTicketing.ts
@@ -5,7 +5,7 @@ import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
 export const useCreateTicketing = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [ticketing, setTicketing] = useState<IntTicket | null>(null);
+  const [ticketing, setTicketing] = useState<IntTicket[]>([]);
 
   const submitTicketing = async (
     ticketData: IntCreateTicket,
@@ -15,7 +15,7 @@ export const useCreateTicketing = () => {
 
     try {
       const newTicketing = await createTicket(ticketData);
-      setTicketing(newTicketing);
+      setTicketing((prev) => [...prev, newTicketing]);
       return newTicketing;
     } catch (err) {
       const error = err instanceof Error ? err : new Error("Unknown error");

--- a/frontend/src/hooks/useCreateTicketing.ts
+++ b/frontend/src/hooks/useCreateTicketing.ts
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { createTicket } from "../api/endPointTickets";
+import { IntCreateTicket, IntTicket } from "../types/ticketingTypes";
+
+
+export const useCreateTicketing = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [ticketing, setTicketing] = useState<IntTicket | null>(null);
+
+  const submitTicketing = async (ticketData: IntCreateTicket): Promise<IntTicket | null> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const newTicketing = await createTicket(ticketData);
+      setTicketing(newTicketing);
+      return newTicketing;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error("Unknown error");
+      setError(error);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { submitTicketing, isLoading, error, ticketing };
+};

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -1,0 +1,34 @@
+export type TicketType = "error" | "suggestion";
+export type TicketStatus = "pending" | "in_progress" | "blocked" | "ready" | "closed";
+export type TicketPriority = "low" | "medium" | "high" | "critical";
+export type AffectedApp = "wiki_frontend" | "wiki_backend" | "code_connect" | "other";
+export type AffectedFunction =
+  | "login"
+  | "challenges"
+  | "resources"
+  | "profile"
+  | "technical_tests"
+  | "code_connect"
+  | "other";
+
+export interface IntCreateTicket {
+  name: string;
+  incident_date: string;
+  affected_app: AffectedApp;
+  type: TicketType;
+  affected_function: AffectedFunction;
+  description: string;
+  forum_answer_id?: number | null;
+  assignee_id?: number | null;
+}
+
+export interface IntTicket extends IntCreateTicket {
+  id: number;
+  code_connect_id: number;
+  status: TicketStatus;
+  priority: TicketPriority;
+  closed_by?: number | null;
+  closed_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -1,7 +1,16 @@
 export type TicketType = "error" | "suggestion";
-export type TicketStatus = "pending" | "in_progress" | "blocked" | "ready" | "closed";
+export type TicketStatus =
+  | "pending"
+  | "in_progress"
+  | "blocked"
+  | "ready"
+  | "closed";
 export type TicketPriority = "low" | "medium" | "high" | "critical";
-export type AffectedApp = "wiki_frontend" | "wiki_backend" | "code_connect" | "other";
+export type AffectedApp =
+  | "wiki_frontend"
+  | "wiki_backend"
+  | "code_connect"
+  | "other";
 export type AffectedFunction =
   | "login"
   | "challenges"


### PR DESCRIPTION
Add `ticketingTypes.ts` with all ticket-related types and interfaces (`IntCreateTicket`, `IntTicket`, union types for status, priority, affected app and function)
Add `endPointTickets.ts` as a stub for the `createTicket` API call (pending merge of the real implementation)
Add `useCreateTicketing` hook managing async state: `ticketing`, `isLoading` and `error`
Add unit tests covering the 3 essential cases: happy path, loading lifecycle, and error recovery

**Notes:** `endPointTickets.ts` is intentionally a stub. The real API implementation is pending merge from a parallel branch. The hook and its tests will not require changes once that merge happens, as the endpoint is fully mocked in tests.

