### PR TITLE
test(ligas): add interaction and accessibility tests for RankingsPage

### DIFF
--- a/frontend/src/pages/__test__/RankingsPage.interactions.test.tsx
+++ b/frontend/src/pages/__test__/RankingsPage.interactions.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import RankingsPage from "../RankingsPage";
+import { getLeagueRanking } from "../../services/leagueService";
+
+vi.mock("../../services/leagueService", () => ({
+  getLeagueRanking: vi.fn(),
+}));
+
+vi.mock("../../components/LeagueToggle/LeagueToggle", () => ({
+  default: ({ view, onChange }: { view: string; onChange: (v: string) => void }) => (
+    <div>
+      <button onClick={() => onChange("weekly")} aria-pressed={view === "weekly"}>Lliga setmanal</button>
+      <button onClick={() => onChange("global")} aria-pressed={view === "global"}>Classificació general</button>
+    </div>
+  ),
+}));
+
+vi.mock("../../components/leagues/StandingsTable", () => ({
+  StandingsTable: () => (
+    <table>
+      <thead><tr><th>Posició</th><th>Usuari</th><th>Punts</th></tr></thead>
+    </table>
+  ),
+}));
+
+vi.mock("../../components/leagues/StandingsEmptyState", () => ({
+  StandingsEmptyState: () => <p>No hi han dades disponibles</p>,
+}));
+
+vi.mock("../../components/leagues/StandingsTableSkeleton", () => ({
+  StandingsTableSkeleton: () => <p>Carregant...</p>,
+}));
+
+const mockRanking = [
+  {
+    position: 1,
+    user_id: 101,
+    points: 94,
+    created_at: "2026-04-24T00:00:00Z",
+    updated_at: "2026-04-24T00:00:00Z",
+  },
+  {
+    position: 2,
+    user_id: 102,
+    points: 88,
+    created_at: "2026-04-24T00:00:00Z",
+    updated_at: "2026-04-24T00:00:00Z",
+  },
+];
+
+describe("RankingsPage — interactions and accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the retry button when there is an error", async () => {
+    vi.mocked(getLeagueRanking).mockRejectedValue(new Error("network error"));
+
+    render(<RankingsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Torna-ho a intentar" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clicking the retry button calls the API again", async () => {
+    vi.mocked(getLeagueRanking)
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(mockRanking);
+
+    const user = userEvent.setup();
+
+    render(<RankingsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Torna-ho a intentar" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Torna-ho a intentar" }),
+    );
+
+    await waitFor(() => {
+      expect(getLeagueRanking).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Posició")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the skeleton after loading completes", async () => {
+    vi.mocked(getLeagueRanking).mockResolvedValue(mockRanking);
+
+    render(<RankingsPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Carregant...")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not show an error when data loads successfully", async () => {
+    vi.mocked(getLeagueRanking).mockResolvedValue(mockRanking);
+
+    render(<RankingsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "No s'han pogut carregar les dades. Torna-ho a intentar.",
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("the error state has role alert for accessibility", async () => {
+    vi.mocked(getLeagueRanking).mockRejectedValue(new Error("network error"));
+
+    render(<RankingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 5 tests for RankingsPage covering interactions and accessibility
- Tests: retry button shown on error, retry calls API again, no skeleton after load, no error on success, error state has role="alert"
- Mocks all dependent components and leagueService

## Depends on
Must be merged after #424 (`feature/393c-ligas-rankingspage-tests`).

## Test plan
- [ ] `npx vitest run src/pages/__test__/RankingsPage.interactions.test.tsx` → 5 tests pass