### PR TITLE
Add component to create new ticket

### DIFF
--- a/frontend/src/components/ticketing/TicketingCreateForm.tsx
+++ b/frontend/src/components/ticketing/TicketingCreateForm.tsx
@@ -1,5 +1,4 @@
 import { FormEvent, JSX, useState } from "react";
-import { toast } from "sonner";
 
 import type {
   AffectedApp,
@@ -19,7 +18,6 @@ interface TicketingCreatePayload {
 }
 
 type TicketingCreateFormProps = {
-  isSubmitting?: boolean;
   onSubmit: (payload: TicketingCreatePayload) => void | Promise<void>;
 };
 
@@ -28,7 +26,6 @@ const createCurrentDate = (): string => {
 };
 
 export const TicketingCreateForm = ({
-  isSubmitting = false,
   onSubmit,
 }: TicketingCreateFormProps): JSX.Element => {
   const [name, setName] = useState<string>("");
@@ -37,11 +34,6 @@ export const TicketingCreateForm = ({
     event: FormEvent<HTMLFormElement>,
   ): Promise<void> => {
     event.preventDefault();
-
-    if (!name.trim()) {
-      toast.error("Escriu el nom del ticket.");
-      return;
-    }
 
     await onSubmit({
       forum_answer_id: null,
@@ -68,7 +60,6 @@ export const TicketingCreateForm = ({
 
         <input
           className="min-h-[52px] border border-gray-600 px-4 py-3 text-sm focus:border-[#B91879] focus:outline-none focus:ring-1 focus:ring-[#B91879]"
-          disabled={isSubmitting}
           id="ticket-name"
           name="ticket-name"
           onChange={(event) => setName(event.target.value)}
@@ -79,10 +70,9 @@ export const TicketingCreateForm = ({
 
         <button
           className="w-fit bg-[#B91879] px-10 py-4 text-sm font-bold text-white hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60"
-          disabled={isSubmitting}
           type="submit"
         >
-          {isSubmitting ? "Creant..." : "Crear ticket"}
+          Crear ticket
         </button>
       </div>
     </form>

--- a/frontend/src/components/ticketing/TicketingCreateForm.tsx
+++ b/frontend/src/components/ticketing/TicketingCreateForm.tsx
@@ -1,0 +1,90 @@
+import { FormEvent, JSX, useState } from "react";
+import { toast } from "sonner";
+
+import type {
+  AffectedApp,
+  AffectedFunction,
+  TicketType,
+} from "../../types/ticketingTypes";
+
+interface TicketingCreatePayload {
+  forum_answer_id: number | null;
+  assignee_id: number | null;
+  name: string;
+  incident_date: string;
+  affected_app: AffectedApp;
+  type: TicketType;
+  affected_function: AffectedFunction;
+  description: string;
+}
+
+type TicketingCreateFormProps = {
+  isSubmitting?: boolean;
+  onSubmit: (payload: TicketingCreatePayload) => void | Promise<void>;
+};
+
+const createCurrentDate = (): string => {
+  return new Date().toISOString().split("T")[0];
+};
+
+export const TicketingCreateForm = ({
+  isSubmitting = false,
+  onSubmit,
+}: TicketingCreateFormProps): JSX.Element => {
+  const [name, setName] = useState<string>("");
+
+  const handleSubmit = async (
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<void> => {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      toast.error("Escriu el nom del ticket.");
+      return;
+    }
+
+    await onSubmit({
+      forum_answer_id: null,
+      assignee_id: null,
+      name: name.trim(),
+      incident_date: createCurrentDate(),
+      affected_app: "wiki_frontend",
+      type: "error",
+      affected_function: "other",
+      description: name.trim(),
+    });
+
+    setName("");
+  };
+
+  return (
+    <form className="mt-8" onSubmit={handleSubmit}>
+      <h3 className="mb-6 text-sm font-bold text-black">Crear ticket</h3>
+
+      <div className="grid gap-6 md:grid-cols-[minmax(0,410px)_auto] md:items-center">
+        <label className="sr-only" htmlFor="ticket-name">
+          Nom del ticket
+        </label>
+
+        <input
+          className="min-h-[52px] border border-gray-600 px-4 py-3 text-sm focus:border-[#B91879] focus:outline-none focus:ring-1 focus:ring-[#B91879]"
+          disabled={isSubmitting}
+          id="ticket-name"
+          name="ticket-name"
+          onChange={(event) => setName(event.target.value)}
+          placeholder="Ticket name..."
+          type="text"
+          value={name}
+        />
+
+        <button
+          className="w-fit bg-[#B91879] px-10 py-4 text-sm font-bold text-white hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isSubmitting}
+          type="submit"
+        >
+          {isSubmitting ? "Creant..." : "Crear ticket"}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/frontend/src/components/ticketing/__test__/TicketingCreateForm.test.tsx
+++ b/frontend/src/components/ticketing/__test__/TicketingCreateForm.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TicketingCreateForm } from "../TicketingCreateForm";
+
+const mocks = vi.hoisted(() => {
+  return {
+    toastErrorMock: vi.fn(),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastErrorMock,
+  },
+}));
+
+const createCurrentDate = (): string => {
+  return new Date().toISOString().split("T")[0];
+};
+
+describe("TicketingCreateForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits a valid ticket payload with default required backend values", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<TicketingCreateForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText("Nom del ticket"), "Error login");
+    await user.click(screen.getByRole("button", { name: "Crear ticket" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      forum_answer_id: null,
+      assignee_id: null,
+      name: "Error login",
+      incident_date: createCurrentDate(),
+      affected_app: "wiki_frontend",
+      type: "error",
+      affected_function: "other",
+      description: "Error login",
+    });
+  });
+
+  it("shows an error when the ticket name is empty", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<TicketingCreateForm onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Crear ticket" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(mocks.toastErrorMock).toHaveBeenCalledWith(
+      "Escriu el nom del ticket.",
+    );
+  });
+
+  it("disables the input and submit button while submitting", () => {
+    const onSubmit = vi.fn();
+
+    render(<TicketingCreateForm isSubmitting={true} onSubmit={onSubmit} />);
+
+    expect(
+      screen.getByLabelText("Nom del ticket").hasAttribute("disabled"),
+    ).toBe(true);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Creant..." })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/components/ticketing/__test__/TicketingCreateForm.test.tsx
+++ b/frontend/src/components/ticketing/__test__/TicketingCreateForm.test.tsx
@@ -4,18 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TicketingCreateForm } from "../TicketingCreateForm";
 
-const mocks = vi.hoisted(() => {
-  return {
-    toastErrorMock: vi.fn(),
-  };
-});
-
-vi.mock("sonner", () => ({
-  toast: {
-    error: mocks.toastErrorMock,
-  },
-}));
-
 const createCurrentDate = (): string => {
   return new Date().toISOString().split("T")[0];
 };

--- a/frontend/src/components/ticketing/__test__/TicketingCreateForm.test.tsx
+++ b/frontend/src/components/ticketing/__test__/TicketingCreateForm.test.tsx
@@ -49,34 +49,4 @@ describe("TicketingCreateForm", () => {
       description: "Error login",
     });
   });
-
-  it("shows an error when the ticket name is empty", async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
-
-    render(<TicketingCreateForm onSubmit={onSubmit} />);
-
-    await user.click(screen.getByRole("button", { name: "Crear ticket" }));
-
-    expect(onSubmit).not.toHaveBeenCalled();
-    expect(mocks.toastErrorMock).toHaveBeenCalledWith(
-      "Escriu el nom del ticket.",
-    );
-  });
-
-  it("disables the input and submit button while submitting", () => {
-    const onSubmit = vi.fn();
-
-    render(<TicketingCreateForm isSubmitting={true} onSubmit={onSubmit} />);
-
-    expect(
-      screen.getByLabelText("Nom del ticket").hasAttribute("disabled"),
-    ).toBe(true);
-
-    expect(
-      screen
-        .getByRole("button", { name: "Creant..." })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-  });
 });

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -1,8 +1,10 @@
 import { JSX } from "react";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
+import { TicketingCreateForm } from "../components/ticketing/TicketingCreateForm";
 
 const TicketingPage = (): JSX.Element => {
+  const handleCreateTicket = (): void => {};
   return (
     <>
       <PageTitle title="Ticketing" />
@@ -10,6 +12,8 @@ const TicketingPage = (): JSX.Element => {
         <h2 className="text-[26px] font-bold text-black text-left">
           Ticketing
         </h2>
+
+        <TicketingCreateForm onSubmit={handleCreateTicket} />
       </Container>
     </>
   );

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -2,9 +2,18 @@ import { JSX } from "react";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
 import { TicketingCreateForm } from "../components/ticketing/TicketingCreateForm";
+import { useCreateTicketing } from "../hooks/useCreateTicketing";
+import type { IntCreateTicket } from "../types/ticketingTypes";
 
 const TicketingPage = (): JSX.Element => {
-  const handleCreateTicket = (): void => {};
+  const { submitTicketing } = useCreateTicketing();
+
+  const handleCreateTicket = async (
+    ticketData: IntCreateTicket,
+  ): Promise<void> => {
+    await submitTicketing(ticketData);
+  };
+
   return (
     <>
       <PageTitle title="Ticketing" />

--- a/frontend/src/pages/__test__/TiketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TiketingPage.test.tsx
@@ -1,11 +1,11 @@
-import { render } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import { BrowserRouter } from "react-router";
 
 import TicketingPage from "../TicketingPage";
 
 describe("TicketingPage", () => {
-  test("renders without errors", () => {
+  it("renders without errors", () => {
     expect(() => {
       render(
         <BrowserRouter>
@@ -13,5 +13,15 @@ describe("TicketingPage", () => {
         </BrowserRouter>,
       );
     }).not.toThrow();
+  });
+
+  it("renders ticketing create form", () => {
+    render(
+      <BrowserRouter>
+        <TicketingPage />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "Crear ticket" })).toBeTruthy();
   });
 });

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -1,0 +1,44 @@
+export type TicketType = "error" | "suggestion";
+
+export type AffectedApp =
+  | "wiki_frontend"
+  | "wiki_backend"
+  | "code_connect"
+  | "other";
+
+export type AffectedFunction =
+  | "login"
+  | "challenges"
+  | "resources"
+  | "profile"
+  | "technical_tests"
+  | "code_connect"
+  | "other";
+
+export interface ApiTicketData {
+  id: number;
+  code_connect_id: number;
+  forum_answer_id: number | null;
+  name: string;
+  incident_date: string;
+  affected_app: AffectedApp;
+  type: TicketType;
+  affected_function: AffectedFunction;
+  description: string;
+}
+
+export interface ApiTicketsResponse {
+  success: boolean;
+  data: ApiTicketData[];
+  message?: string;
+}
+
+export interface TicketingError {
+  message: string;
+}
+
+export interface UseTicketingGetAllState {
+  tickets: ApiTicketData[];
+  isLoading: boolean;
+  errorMessage: string | null;
+}


### PR DESCRIPTION
## Add ticket create form component

Implemented a simple React form component to create new tickets.  
The form collects the ticket name and sends a payload with default values required by the backend.  
Designed the component to be independent from the API by using an `onSubmit` prop.  
Added validation to ensure the required field is filled before submitting.  
Included unit tests to verify form rendering, validation, disabled state, and payload structure.
<img width="914" height="330" alt="image" src="https://github.com/user-attachments/assets/23bff769-64f6-4fa3-95cc-d92a3401be57" />
