### PR TITLE
feat(ligas): add StandingsRow and StandingsTable components (#359a)

### DIFF
--- a/frontend/src/components/leagues/StandingsRow.tsx
+++ b/frontend/src/components/leagues/StandingsRow.tsx
@@ -1,0 +1,13 @@
+import type { Liga } from "../../types/league";
+const rc = (p: number) =>
+  p <= 3 ? "bg-[#d1fae5]" : p >= 8 ? "bg-[#ffe4e6]" : "bg-white";
+const td = "py-3 px-4 text-center text-[14px]";
+export const StandingsRow = ({ liga }: { liga: Liga }) => (
+  <tr className={`${rc(liga.position)} border-b border-gray-200`}>
+    <td className={`${td} font-semibold`}>{liga.position}</td>
+    <td className={td}>User_{liga.user_id}</td>
+    <td className={`${td} text-gray-500`}>—</td>
+    <td className={`${td} text-gray-500`}>—</td>
+    <td className={`${td} font-semibold`}>{liga.points}</td>
+  </tr>
+);

--- a/frontend/src/components/leagues/StandingsTable.tsx
+++ b/frontend/src/components/leagues/StandingsTable.tsx
@@ -1,0 +1,39 @@
+import type { Liga } from "../../types/league";
+import { StandingsRow } from "./StandingsRow";
+const H = ["Posició", "Username", "Estatus", "Llengua", "Punts"];
+type Props = { ligas: Liga[]; highlighted?: boolean };
+export const StandingsTable = ({ ligas, highlighted = false }: Props) => {
+  if (!ligas.length)
+    return <p className="text-center text-gray-400 py-4">No hi han dades</p>;
+  const rows = ligas.map((l) => <StandingsRow key={l.user_id} liga={l} />);
+  const ths = H.map((h) => (
+    <th key={h} className="py-3 px-4 text-center font-semibold text-[14px]">
+      {h}
+    </th>
+  ));
+  return highlighted ? (
+    <div className="w-full overflow-x-auto border-2 border-blue-400 rounded-lg">
+      <table className="w-full table-fixed">
+        <thead>
+          <tr>{ths}</tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    </div>
+  ) : (
+    <div className="w-full overflow-x-auto">
+      <div className="grid grid-cols-5 px-4 pb-2">
+        {H.map((h) => (
+          <span key={h} className="text-center font-semibold text-[14px]">
+            {h}
+          </span>
+        ))}
+      </div>
+      <div className="border-2 border-gray-400 rounded-lg overflow-hidden">
+        <table className="w-full table-fixed">
+          <tbody>{rows}</tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/leagues/__test__/StandingsTable.test.tsx
+++ b/frontend/src/components/leagues/__test__/StandingsTable.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect } from "vitest";
+import { StandingsTable } from "../StandingsTable";
+import { StandingsRow } from "../StandingsRow";
+import type { Liga } from "../../../types/league";
+
+const mockLigas: Liga[] = [
+  { position: 1, user_id: 101, points: 94, created_at: "", updated_at: "" },
+  { position: 2, user_id: 102, points: 88, created_at: "", updated_at: "" },
+  { position: 8, user_id: 103, points: 40, created_at: "", updated_at: "" },
+];
+
+describe("StandingsTable", () => {
+  it("renders all rows", () => {
+    render(<StandingsTable ligas={mockLigas} />);
+    expect(screen.getByText("User_101")).toBeInTheDocument();
+    expect(screen.getByText("User_102")).toBeInTheDocument();
+    expect(screen.getByText("User_103")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no data", () => {
+    render(<StandingsTable ligas={[]} />);
+    expect(screen.getByText("No hi han dades")).toBeInTheDocument();
+  });
+
+  it("renders with blue border when highlighted", () => {
+    const { container } = render(<StandingsTable ligas={mockLigas} highlighted />);
+    expect(container.firstChild).toHaveClass("border-blue-400");
+  });
+});
+
+describe("StandingsRow", () => {
+  const renderRow = (liga: Liga) =>
+    render(
+      <table>
+        <tbody>
+          <StandingsRow liga={liga} />
+        </tbody>
+      </table>,
+    );
+
+  it("applies green highlight to top 3 positions", () => {
+    renderRow(mockLigas[0]);
+    expect(screen.getByRole("row")).toHaveClass("bg-[#d1fae5]");
+  });
+
+  it("applies pink highlight to danger zone (position >= 8)", () => {
+    renderRow(mockLigas[2]);
+    expect(screen.getByRole("row")).toHaveClass("bg-[#ffe4e6]");
+  });
+
+  it("applies white background for mid positions", () => {
+    const midLiga: Liga = { position: 5, user_id: 105, points: 60, created_at: "", updated_at: "" };
+    renderRow(midLiga);
+    expect(screen.getByRole("row")).toHaveClass("bg-white");
+  });
+});


### PR DESCRIPTION
## Qué hace

Añade los componentes de tabla de clasificación para la página de ligas:

- `StandingsRow` — fila de tabla con resaltado de color por posición (verde top 3, rosa descenso)
- `StandingsTable` — tabla en dos modos: normal (cabecera fuera del recuadro gris) y `highlighted` (borde azul completo)

## Componentes

- `frontend/src/components/leagues/StandingsRow.tsx`
- `frontend/src/components/leagues/StandingsTable.tsx`
- `frontend/src/components/leagues/__test__/StandingsTable.test.tsx` — 6 tests (render, empty state, highlighted border, colores por posición)

## Relación con otras PRs

Esta PR es base de la PR #442 (estilos y responsividad de RankingsPage). Separada a petición del revisor para mantener el scope acotado.