### PR TITLE
feat(ticketing): Add TicketSeeder covering all ticket statuses #448

### DIFF
--- a/backend/src/database/factories/TicketFactory.php
+++ b/backend/src/database/factories/TicketFactory.php
@@ -30,9 +30,49 @@ class TicketFactory extends Factory
             'type' => fake()->randomElement(['error', 'suggestion']),
             'affected_function' => fake()->randomElement(AffectedFunctionEnum::values()),
             'description' => fake()->paragraph(),
-            'status' => 'pending',
+            'status' => TicketStatusEnum::Pending->value,
             'priority' => fake()->randomElement(TicketPriorityEnum::values()),
         ];
-        
+    }
+
+    public function pending(): static
+    {
+        return $this->state(fn () => [
+            'status' => TicketStatusEnum::Pending->value,
+        ]);
+    }
+
+    public function inProgress(): static
+    {
+        return $this->state(fn () => [
+            'status' => TicketStatusEnum::InProgress->value,
+            'assignee_id' => User::factory(),
+        ]);
+    }
+
+    public function blocked(): static
+    {
+        return $this->state(fn () => [
+            'status' => TicketStatusEnum::Blocked->value,
+            'assignee_id' => User::factory(),
+        ]);
+    }
+
+    public function ready(): static
+    {
+        return $this->state(fn () => [
+            'status' => TicketStatusEnum::Ready->value,
+            'assignee_id' => User::factory(),
+        ]);
+    }
+
+    public function closed(): static
+    {
+        return $this->state(fn () => [
+            'status' => TicketStatusEnum::Closed->value,
+            'assignee_id' => User::factory(),
+            'closed_by' => User::factory(),
+            'closed_at' => now(),
+        ]);
     }
 }

--- a/backend/src/database/seeders/DatabaseSeeder.php
+++ b/backend/src/database/seeders/DatabaseSeeder.php
@@ -21,27 +21,29 @@ use Database\Seeders\RoleSeeder;
 use Database\Seeders\PermissionSeeder;
 use Database\Seeders\RolePermissionSeeder;
 use Database\Seeders\LigaSeeder;
+use Database\Seeders\TicketSeeder;
 
 
 class DatabaseSeeder extends Seeder
 {
-    
+
     public function run(): void
     {
         $this->call([
-            RoleSeeder::class,              
-            PermissionSeeder::class,       
-            RolePermissionSeeder::class,    
-            UserSeeder::class, 
-            LigaSeeder::class,             
-            TagSeeder::class,               
-            ResourceSeeder::class,         
-            //BookmarkSeeder::class,         
-            //LikeSeeder::class,              
+            RoleSeeder::class,
+            PermissionSeeder::class,
+            RolePermissionSeeder::class,
+            UserSeeder::class,
+            LigaSeeder::class,
+            TagSeeder::class,
+            ResourceSeeder::class,
+            //BookmarkSeeder::class,
+            //LikeSeeder::class,
             TechnicalTestSeeder::class,
             ListProjectsSeeder::class,
             ContributorListProjectSeeder::class,
             ForumSeeder::class,
+            TicketSeeder::class,
         ]);
     }
 }

--- a/backend/src/database/seeders/TicketSeeder.php
+++ b/backend/src/database/seeders/TicketSeeder.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class TicketSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $users = User::all();
+
+        Ticket::factory(3)
+            ->pending()
+            ->create([
+                'code_connect_id' => fn () => $users->random()->id,
+            ]);
+
+        Ticket::factory(2)
+            ->inProgress()
+            ->create([
+                'code_connect_id' => fn () => $users->random()->id,
+                'assignee_id'     => fn () => $users->random()->id,
+            ]);
+
+        Ticket::factory(2)
+            ->blocked()
+            ->create([
+                'code_connect_id' => fn () => $users->random()->id,
+                'assignee_id'     => fn () => $users->random()->id,
+            ]);
+
+        Ticket::factory(2)
+            ->ready()
+            ->create([
+                'code_connect_id' => fn () => $users->random()->id,
+                'assignee_id'     => fn () => $users->random()->id,
+            ]);
+
+        Ticket::factory(3)
+            ->closed()
+            ->create([
+                'code_connect_id' => fn () => $users->random()->id,
+                'assignee_id'     => fn () => $users->random()->id,
+                'closed_by'       => fn () => $users->random()->id,
+            ]);
+    }
+}


### PR DESCRIPTION
#### Goal
Create an initial ticket seeder that covers all possible ticket statuses in the system.

#### Changes
- `TicketFactory`: added state methods for each status (pending, in_progress, blocked, ready, closed)
- `TicketSeeder`: new seeder that creates 12 tickets covering all 5 statuses
- `DatabaseSeeder`: registered TicketSeeder in the execution order

#### Pending
- Validate local execution with `docker exec -it backend php artisan db:seed --class=TicketSeeder`
- Create PR towards develop

