### PR TITLE
fix / roadmap display - corresponding type and test update

### DIFF
--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -1,8 +1,8 @@
-import PageTitle from "../components/ui/PageTitle";
-import useCodeConnectDetails from "../hooks/useCodeConnectDetails";
+import { useParams } from "react-router";
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
 import Container from "../components/ui/Container";
-import { useParams } from "react-router";
+import PageTitle from "../components/ui/PageTitle";
+import useCodeConnectDetails from "../hooks/useCodeConnectDetails";
 import { displayLanguageIcon } from "../utils/iconUtils";
 
 const CodeConnectDetails = () => {
@@ -38,12 +38,16 @@ const CodeConnectDetails = () => {
                 {codeConnectProject.data?.description ||
                   "Aquesta informació no està disponible a la base de dades."}
               </p>
-
               <h3 className="text-[22px] font-extrabold mb-5">Roadmap:</h3>
-              <p className="text-[16px]">
-                {codeConnectProject.data?.roadmap ||
-                  "Aquesta informació no està disponible a la base de dades."}
-              </p>
+              {codeConnectProject?.data?.roadmap?.length ? (
+                <>
+                  <ul>
+                    {codeConnectProject.data.roadmap.map((task, index) => (
+                      <li key={index}>{task.task}</li>
+                    ))}
+                  </ul>
+                </>
+              ) : "Aquesta informació no està disponible a la base de dades."}
             </div>
 
             <div className="lg:w-1/3 flex-shrink-0 min-w-[320px] flex lg:justify-end">

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -47,7 +47,9 @@ const CodeConnectDetails = () => {
                     ))}
                   </ul>
                 </>
-              ) : "Aquesta informació no està disponible a la base de dades."}
+              ) : (
+                "Aquesta informació no està disponible a la base de dades."
+              )}
             </div>
 
             <div className="lg:w-1/3 flex-shrink-0 min-w-[320px] flex lg:justify-end">

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -25,7 +25,10 @@ describe("CodeConnectDetails Page", () => {
       data: {
         title: "Super Projecte de Prova",
         description: "Descripció de prova del projecte",
-        roadmap: [{ task: "Tarea 1", done: false }, { task: "Tarea 2", done: false }],
+        roadmap: [
+          { task: "Tarea 1", done: false },
+          { task: "Tarea 2", done: false },
+        ],
         contributors: [],
         time_duration: "2 setmanes",
         language_frontend: "react",

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, type Mock } from "vitest";
-import CodeConnectDetails from "../CodeConnectDetails";
 import useCodeConnectDetails from "../../hooks/useCodeConnectDetails";
+import CodeConnectDetails from "../CodeConnectDetails";
 
 vi.mock("react-router", () => ({
   useParams: () => ({ projectId: "1" }),
@@ -25,7 +25,7 @@ describe("CodeConnectDetails Page", () => {
       data: {
         title: "Super Projecte de Prova",
         description: "Descripció de prova del projecte",
-        roadmap: "Roadmap de prova del projecte",
+        roadmap: [{ task: "Tarea 1", done: false }, { task: "Tarea 2", done: false }],
         contributors: [],
         time_duration: "2 setmanes",
         language_frontend: "react",
@@ -43,7 +43,7 @@ describe("CodeConnectDetails Page", () => {
 
     expect(screen.getByText("Super Projecte de Prova")).toBeTruthy();
     expect(screen.getByText("Descripció de prova del projecte")).toBeTruthy();
-    expect(screen.getByText("Roadmap de prova del projecte")).toBeTruthy();
+    expect(screen.getByText("Tarea 1")).toBeTruthy();
     expect(screen.getByTestId("mock-project-team")).toBeTruthy();
     expect(screen.getByText("Roadmap:")).toBeTruthy();
     expect(screen.getByText("Descripció:")).toBeTruthy();
@@ -54,7 +54,7 @@ describe("CodeConnectDetails Page", () => {
       data: {
         title: "Projecte Antic",
         description: "",
-        roadmap: "",
+        roadmap: [],
         contributors: [],
         time_duration: "1 mes",
         language_frontend: "javascript",

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -35,7 +35,7 @@ export interface ApiProjectData {
   description?: string;
   language_backend: string;
   language_frontend: string;
-  roadmap?: { task: string, done: boolean }[];
+  roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
 }

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -35,7 +35,7 @@ export interface ApiProjectData {
   description?: string;
   language_backend: string;
   language_frontend: string;
-  roadmap?: string;
+  roadmap?: { task: string, done: boolean }[];
   time_duration: string;
   title: string;
 }


### PR DESCRIPTION
Del sprint anterior, se ha corregido un error debido al roadmap que antes era un string y ahora un array. 
Archivos tocados: CodeConnectDetails y su test.