### PR TITLE
506 feat: show pending join requests in project detail for owner and members

### DIFF
--- a/frontend/src/api/endPointCodeConnect.ts
+++ b/frontend/src/api/endPointCodeConnect.ts
@@ -3,6 +3,7 @@ import type { IntCodeConnect } from "../types";
 import type {
   ApiProjectResponse,
   ApiProjectsResponse,
+  ApiContributor,
 } from "../types/codeConnectTypes";
 
 export type CodeConnectError = {
@@ -173,3 +174,43 @@ export const fetchCodeConnectAllProjects = async (
     throw error;
   }
 };
+
+  export const fetchProjectContributors = async (
+    projectId: number,
+     ): Promise<ApiContributor[]> => {
+      const url = `${API_URL}${END_POINTS.codeconnect.get}/${projectId}/contributors`;
+      try {
+        const response = await fetch(url, {
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok) return [];
+        const data = (await response.json()) as { data: ApiContributor[] };
+        return data.data ?? [];
+      } catch {
+        return [];
+      }
+  };
+
+export const updateContributorStatus = async (
+  projectId: number,
+    contributorId: number,
+    status: 'accepted' | 'rejected',
+  ): Promise<boolean> => {
+    const token = localStorage.getItem('auth_token');
+    const url = `${API_URL}${END_POINTS.codeconnect.get}/${projectId}/contributors/${contributorId}/status`;
+    try {
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status }),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+};
+

--- a/frontend/src/components/code-connect/pendingRequests/PendingRequests.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/PendingRequests.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import type { ApiContributor } from '../../../types/codeConnectTypes';
+import {
+  fetchProjectContributors,
+  updateContributorStatus,
+} from '../../../api/endPointCodeConnect';
+
+interface PendingRequestsProps {
+  projectId: number;
+  ownerId: number;
+  currentUserId?: number;
+}
+
+const PendingRequests = ({ projectId, ownerId, currentUserId }: PendingRequestsProps) => {
+  const [contributors, setContributors] = useState<ApiContributor[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadContributors = async () => {
+    setIsLoading(true);
+    const data = await fetchProjectContributors(projectId);
+    setContributors(data);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    void loadContributors();
+  }, [projectId]);
+
+  if (isLoading) return null;
+
+  const isOwner = currentUserId === ownerId;
+  const isAcceptedMember = contributors.some(
+    (c) => c.user_id === currentUserId && c.status === 'accepted',
+  );
+
+  if (!currentUserId || (!isOwner && !isAcceptedMember)) return null;
+
+  const pendingContributors = contributors.filter((c) => c.status === 'pending');
+
+  if (pendingContributors.length === 0) return null;
+
+  const handleAction = async (contributorId: number, status: 'accepted' | 'rejected') => {
+    const ok = await updateContributorStatus(projectId, contributorId, status);
+    if (ok) await loadContributors();
+  };
+
+  return (
+    <div className="mt-8 border-t pt-6">
+      <h3 className="text-[22px] font-extrabold mb-5">Sol·licituds pendents:</h3>
+      <ul className="flex flex-col gap-3">
+        {pendingContributors.map((contributor) => (
+          <li
+            key={contributor.id}
+            className="flex items-center justify-between gap-4 p-3 border rounded-lg"
+          >
+            <span className="font-semibold">[{contributor.user.name}]</span>
+            <span className="text-sm text-gray-500">{contributor.programming_role}</span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => void handleAction(contributor.id, 'accepted')}
+                className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700 text-sm"
+              >
+                Acceptar
+              </button>
+              <button
+                onClick={() => void handleAction(contributor.id, 'rejected')}
+                className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
+              >
+                Rebutjar
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PendingRequests;

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -1,12 +1,15 @@
 import { useParams } from "react-router";
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
+import PendingRequests from "../components/code-connect/pendingRequests/PendingRequests";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
 import useCodeConnectDetails from "../hooks/useCodeConnectDetails";
 import { displayLanguageIcon } from "../utils/iconUtils";
+import { useUserContext } from "../context/UserContext";
 
 const CodeConnectDetails = () => {
   const { projectId } = useParams<{ projectId: string }>();
+  const { user } = useUserContext();
 
   const { codeConnectProject, isLoading, errorMessage } = useCodeConnectDetails(
     projectId || null,
@@ -26,45 +29,51 @@ const CodeConnectDetails = () => {
         {!isLoading && errorMessage && <p>{errorMessage}</p>}
 
         {!isLoading && !errorMessage && codeConnectProject?.data && (
-          <div className="flex flex-col lg:flex-row gap-8 w-full">
-            <div className="lg:w-2/3">
-              <h2 className="text-[26px] font-extrabold text-left mb-10">
-                {codeConnectProject.data.title ||
-                  "No s'ha pogut carregar el títol del projecte."}
-              </h2>
+          <>
+            <div className="flex flex-col lg:flex-row gap-8 w-full">
+              <div className="lg:w-2/3">
+                <h2 className="text-[26px] font-extrabold text-left mb-10">
+                  {codeConnectProject.data.title ||
+                    "No s'ha pogut carregar el títol del projecte."}
+                </h2>
 
-              <h3 className="text-[22px] font-extrabold mb-5">Descripció:</h3>
-              <p className="text-[16px] mb-10">
-                {codeConnectProject.data?.description ||
-                  "Aquesta informació no està disponible a la base de dades."}
-              </p>
-              <h3 className="text-[22px] font-extrabold mb-5">Roadmap:</h3>
-              {codeConnectProject?.data?.roadmap?.length ? (
-                <>
+                <h3 className="text-[22px] font-extrabold mb-5">Descripció:</h3>
+                <p className="text-[16px] mb-10">
+                  {codeConnectProject.data?.description ||
+                    "Aquesta informació no està disponible a la base de dades."}
+                </p>
+                <h3 className="text-[22px] font-extrabold mb-5">Roadmap:</h3>
+                {codeConnectProject?.data?.roadmap?.length ? (
                   <ul>
                     {codeConnectProject.data.roadmap.map((task, index) => (
                       <li key={index}>{task.task}</li>
                     ))}
                   </ul>
-                </>
-              ) : (
-                "Aquesta informació no està disponible a la base de dades."
-              )}
+                ) : (
+                  "Aquesta informació no està disponible a la base de dades."
+                )}
+              </div>
+
+              <div className="lg:w-1/3 flex-shrink-0 min-w-[320px] flex lg:justify-end">
+                <ProjectTeam
+                  logoFront={displayLanguageIcon(
+                    codeConnectProject.data.language_frontend,
+                  )}
+                  logoBack={displayLanguageIcon(
+                    codeConnectProject.data.language_backend,
+                  )}
+                  contributors={codeConnectProject.data.contributors}
+                  timeDuration={codeConnectProject.data.time_duration}
+                />
+              </div>
             </div>
 
-            <div className="lg:w-1/3 flex-shrink-0 min-w-[320px] flex lg:justify-end">
-              <ProjectTeam
-                logoFront={displayLanguageIcon(
-                  codeConnectProject.data.language_frontend,
-                )}
-                logoBack={displayLanguageIcon(
-                  codeConnectProject.data.language_backend,
-                )}
-                contributors={codeConnectProject.data.contributors}
-                timeDuration={codeConnectProject.data.time_duration}
-              />
-            </div>
-          </div>
+            <PendingRequests
+              projectId={codeConnectProject.data.id}
+              ownerId={codeConnectProject.data.user_id}
+              currentUserId={user?.id}
+            />
+          </>
         )}
       </Container>
     </>

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -31,6 +31,7 @@ export interface ApiProjectContributor {
 
 export interface ApiProjectData {
   id: number;
+  user_id: number;
   contributors: ApiProjectContributor[];
   description?: string;
   language_backend: string;
@@ -38,6 +39,18 @@ export interface ApiProjectData {
   roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
+}
+
+  export interface ApiContributor {
+  id: number;
+  user_id: number;
+  programming_role: string;
+  status: 'pending' | 'accepted' | 'rejected';
+  user: {
+    id: number;
+    name: string;
+    email: string;
+  };
 }
 
 export interface ApiProjectsResponse {


### PR DESCRIPTION
###Descripción:
The backend already had the necessary endpoints in place:
- `GET /api/codeconnect/{id}/contributors` returns `status` and user data
- `PATCH /api/codeconnect/{id}/contributors/{id}/status` handles accept/reject with member authorization

This PR adds the frontend layer to expose that functionality in the UI.

###Changes:
- `ApiContributor` type added with `id`, `user_id`, `status` and `user` fields
- `user_id` added to `ApiProjectData` to identify the project owner
- `fetchProjectContributors()` — fetches all contributors for a project
- `updateContributorStatus()` — sends PATCH request with Bearer token
- New `PendingRequests` component renders pending join requests at the bottom of the project detail page
- `CodeConnectDetails` page integrates the new component

###Behavior:
- Section is only visible to the project owner or accepted contributors
- Each pending request shows username, role, and Accept / Reject buttons
- On action, the list refreshes automatically
