### PR TITLE
feat: update LigaController and tests with league_id and weekly points

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -11,52 +11,83 @@ use Illuminate\Http\Request;
 
 class LigaController extends Controller
 {
-
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'user_id' => 'required|integer|exists:users,id',
+            'user_id'   => 'required|integer|exists:users,id',
+            'league_id' => 'required|integer',
         ]);
 
-        if (Liga::where('user_id', $validated['user_id'])->exists()) {
-            return response()->json(['error' => 'Entry already exists for this user'], 409);
+        if (Liga::where('user_id', $validated['user_id'])
+            ->where('league_id', $validated['league_id'])
+            ->exists()
+        ) {
+            return response()->json([
+                'error' => 'Entry already exists for this user in this league'
+            ], 409);
         }
 
-        $entry = Liga::create(['user_id' => $validated['user_id'], 'points' => 0]);
+        $user = User::findOrFail($validated['user_id']);
+
+        $entry = Liga::create([
+            'user_id'       => $user->id,
+            'league_id'     => $validated['league_id'],
+            'user_name'     => $user->github_user_name ?? $user->name,
+            'points'        => 0,
+            'points_weekly' => 0,
+        ]);
 
         return response()->json($entry, 201);
     }
 
     public function ranking()
     {
-        $entries = Liga::orderBy('points', 'desc')
+        return Liga::orderBy('points', 'desc')
             ->get()
             ->values()
-            ->map(fn ($entry, $index) => [
-                'position'   => $index + 1,
-                'user_id'    => $entry->user_id,
-                'points'     => $entry->points,
-                'created_at' => $entry->created_at,
-                'updated_at' => $entry->updated_at,
+            ->map(fn ($e, $i) => [
+                'position'      => $i + 1,
+                'user_id'       => $e->user_id,
+                'user_name'     => $e->user_name,
+                'points'        => $e->points,
+                'points_weekly' => $e->points_weekly,
+                'created_at'    => $e->created_at,
+                'updated_at'    => $e->updated_at,
             ]);
-
-        return response()->json($entries);
     }
 
-    public function addPoints(User $user): JsonResponse
+    public function addPoints(Request $request, int $userId): JsonResponse
     {
-        $entry = Liga::where('user_id', $user->id)->first();
+        $user = User::find($userId);
 
-        if (!$entry) {
-            return response()->json(['message' => 'User has not opted in to the liga'], 403);
+        if (!$user) {
+            return response()->json([], 404);
         }
 
-        $entry->increment('points', 5);
+        $validated = $request->validate([
+            'league_id' => 'required|integer',
+            'points'    => 'nullable|integer|min:1',
+        ]);
+
+        $entry = Liga::where('user_id', $user->id)
+            ->where('league_id', $validated['league_id'])
+            ->first();
+
+        if (!$entry) {
+            return response()->json([
+                'message' => 'User has not opted in to the liga'
+            ], 403);
+        }
+
+        $points = $validated['points'] ?? 5;
+
+        $entry->increment('points', $points);
+        $entry->increment('points_weekly', $points);
 
         return response()->json([
-            'user_id' => $user->id,
-            'points'  => $entry->points,
+            'user_id'       => $user->id,
+            'points'        => $entry->points,
+            'points_weekly' => $entry->points_weekly,
         ]);
     }
 }
-

--- a/backend/src/tests/Feature/LigaTest/LigaAddPointsTest.php
+++ b/backend/src/tests/Feature/LigaTest/LigaAddPointsTest.php
@@ -14,7 +14,6 @@ class LigaAddPointsTest extends TestCase
     use RefreshDatabase;
 
     protected User $user;
-    protected Liga $ligaEntry;
 
     public function setUp(): void
     {
@@ -22,44 +21,48 @@ class LigaAddPointsTest extends TestCase
 
         $this->user = User::factory()->create();
 
-        $this->ligaEntry = Liga::create([
-            'user_id' => $this->user->id,
-            'points'  => 0,
+        Liga::create([
+            'user_id'       => $this->user->id,
+            'league_id'     => 1,
+            'points'        => 0,
+            'points_weekly' => 0,
         ]);
     }
 
-     
     public function test_put_increments_points_by_5(): void
     {
-        
-        $response = $this->putJson('/api/ligas/' . $this->user->id . '/points');
-
-        $response->assertStatus(200);
-        $response->assertJson([
-            'user_id' => $this->user->id,
-            'points'  => 5,
+        $response = $this->putJson("/api/ligas/{$this->user->id}/points", [
+            'league_id' => 1,
         ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'user_id' => $this->user->id,
+                'points'  => 5,
+            ]);
     }
 
-     public function test_put_three_times_gives_15_points(): void
+    public function test_put_three_times_gives_15_points(): void
     {
-        
-        $this->putJson('/api/ligas/' . $this->user->id . '/points');
-        $this->putJson('/api/ligas/' . $this->user->id . '/points');
-        $response = $this->putJson('/api/ligas/' . $this->user->id . '/points');
+        $this->putJson("/api/ligas/{$this->user->id}/points", ['league_id' => 1]);
+        $this->putJson("/api/ligas/{$this->user->id}/points", ['league_id' => 1]);
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'user_id' => $this->user->id,
-            'points'  => 15,
+        $response = $this->putJson("/api/ligas/{$this->user->id}/points", [
+            'league_id' => 1,
         ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'user_id' => $this->user->id,
+                'points'  => 15,
+            ]);
     }
 
-
-     public function test_put_returns_404_for_unknown_user(): void
+    public function test_put_returns_404_for_unknown_user(): void
     {
-        
-        $response = $this->putJson('/api/ligas/99999/points');
+        $response = $this->putJson('/api/ligas/99999/points', [
+            'league_id' => 1,
+        ]);
 
         $response->assertStatus(404);
     }
@@ -68,11 +71,13 @@ class LigaAddPointsTest extends TestCase
     {
         $userWithoutLiga = User::factory()->create();
 
-        $response = $this->putJson('/api/ligas/' . $userWithoutLiga->id . '/points');
+        $response = $this->putJson("/api/ligas/{$userWithoutLiga->id}/points", [
+            'league_id' => 1,
+        ]);
 
-        $response->assertStatus(403);
-        $response->assertJson(['message' => 'User has not opted in to the liga']);
+        $response->assertStatus(403)
+            ->assertJson([
+                'message' => 'User has not opted in to the liga'
+            ]);
     }
-
 }
-

--- a/backend/src/tests/Feature/LigaTest/LigaGetRankingTest.php
+++ b/backend/src/tests/Feature/LigaTest/LigaGetRankingTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Feature\LigaTests;
 
-use Tests\TestCase;
 use App\Models\Liga;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class LigaGetRankingTest extends TestCase
 {
     use RefreshDatabase;
-
 
     public function test_endpoint_is_public_and_requires_no_auth_token(): void
     {
@@ -32,13 +31,27 @@ class LigaGetRankingTest extends TestCase
     public function test_response_shape_matches_expected_contract(): void
     {
         $user = User::factory()->create();
-        Liga::factory()->create(['user_id' => $user->id, 'points' => 50]);
+
+        Liga::factory()->create([
+            'user_id'       => $user->id,
+            'league_id'     => 1,
+            'points'        => 50,
+            'points_weekly' => 0,
+        ]);
 
         $response = $this->getJson('/api/ligas/ranking');
 
         $response->assertStatus(200)
             ->assertJsonStructure([
-                '*' => ['position', 'user_id', 'points', 'created_at', 'updated_at'],
+                '*' => [
+                    'position',
+                    'user_id',
+                    'user_name',
+                    'points',
+                    'points_weekly',
+                    'created_at',
+                    'updated_at',
+                ],
             ]);
     }
 
@@ -48,15 +61,33 @@ class LigaGetRankingTest extends TestCase
         $userB = User::factory()->create();
         $userC = User::factory()->create();
 
-        Liga::factory()->create(['user_id' => $userA->id, 'points' => 10]);
-        Liga::factory()->create(['user_id' => $userB->id, 'points' => 30]);
-        Liga::factory()->create(['user_id' => $userC->id, 'points' => 20]);
+        Liga::factory()->create([
+            'user_id'       => $userA->id,
+            'league_id'     => 1,
+            'points'        => 10,
+            'points_weekly' => 0,
+        ]);
+
+        Liga::factory()->create([
+            'user_id'       => $userB->id,
+            'league_id'     => 1,
+            'points'        => 30,
+            'points_weekly' => 0,
+        ]);
+
+        Liga::factory()->create([
+            'user_id'       => $userC->id,
+            'league_id'     => 1,
+            'points'        => 20,
+            'points_weekly' => 0,
+        ]);
 
         $response = $this->getJson('/api/ligas/ranking');
 
         $response->assertStatus(200);
 
         $data = $response->json();
+
         $this->assertEquals(30, $data[0]['points']);
         $this->assertEquals(20, $data[1]['points']);
         $this->assertEquals(10, $data[2]['points']);
@@ -67,7 +98,12 @@ class LigaGetRankingTest extends TestCase
         $users = User::factory(3)->create();
 
         foreach ($users as $i => $user) {
-            Liga::factory()->create(['user_id' => $user->id, 'points' => ($i + 1) * 10]);
+            Liga::factory()->create([
+                'user_id'       => $user->id,
+                'league_id'     => 1,
+                'points'        => ($i + 1) * 10,
+                'points_weekly' => 0,
+            ]);
         }
 
         $response = $this->getJson('/api/ligas/ranking');
@@ -75,6 +111,7 @@ class LigaGetRankingTest extends TestCase
         $response->assertStatus(200);
 
         $data = $response->json();
+
         foreach ($data as $index => $entry) {
             $this->assertEquals($index + 1, $entry['position']);
         }
@@ -83,39 +120,51 @@ class LigaGetRankingTest extends TestCase
     public function test_users_with_zero_points_appear_in_ranking(): void
     {
         $user = User::factory()->create();
-        Liga::factory()->create(['user_id' => $user->id, 'points' => 0]);
 
+        Liga::factory()->create([
+            'user_id'       => $user->id,
+            'league_id'     => 1,
+            'points'        => 0,
+            'points_weekly' => 0,
+        ]);
 
         $response = $this->getJson('/api/ligas/ranking');
 
-
         $response->assertStatus(200);
+
         $this->assertCount(1, $response->json());
         $this->assertEquals(0, $response->json()[0]['points']);
     }
-
 
     public function test_users_with_equal_points_get_sequential_positions(): void
     {
         $userA = User::factory()->create();
         $userB = User::factory()->create();
 
+        Liga::factory()->create([
+            'user_id'       => $userA->id,
+            'league_id'     => 1,
+            'points'        => 50,
+            'points_weekly' => 0,
+        ]);
 
-        Liga::factory()->create(['user_id' => $userA->id, 'points' => 50]);
-        Liga::factory()->create(['user_id' => $userB->id, 'points' => 50]);
-
+        Liga::factory()->create([
+            'user_id'       => $userB->id,
+            'league_id'     => 1,
+            'points'        => 50,
+            'points_weekly' => 0,
+        ]);
 
         $response = $this->getJson('/api/ligas/ranking');
 
-
         $response->assertStatus(200);
 
-
         $data = $response->json();
+
         $this->assertEquals(1, $data[0]['position']);
         $this->assertEquals(2, $data[1]['position']);
+
         $this->assertEquals(50, $data[0]['points']);
         $this->assertEquals(50, $data[1]['points']);
     }
-
 }

--- a/backend/src/tests/Feature/LigaTest/LigaStubTest.php
+++ b/backend/src/tests/Feature/LigaTest/LigaStubTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\LigaTest;
 
-use Tests\TestCase;
 use App\Models\Liga;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-
+use Tests\TestCase;
 
 class LigaStubTest extends TestCase
 {
@@ -17,6 +16,7 @@ class LigaStubTest extends TestCase
     public function test_ranking_endpoint_is_accessible(): void
     {
         $response = $this->getJson('/api/ligas/ranking');
+
         $response->assertStatus(200);
     }
 
@@ -24,7 +24,10 @@ class LigaStubTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->postJson('/api/ligas', ['user_id' => $user->id]);
+        $response = $this->postJson('/api/ligas', [
+            'user_id'   => $user->id,
+            'league_id' => 1,
+        ]);
 
         $response->assertStatus(201);
     }
@@ -33,13 +36,16 @@ class LigaStubTest extends TestCase
     {
         $user = User::factory()->create();
 
-        // addPoints uses firstOrFail(), so a liga entry must exist before calling the endpoint
         Liga::create([
-            'user_id' => $user->id,
-            'points' => 0,
+            'user_id'       => $user->id,
+            'league_id'     => 1,
+            'points'        => 0,
+            'points_weekly' => 0,
         ]);
 
-        $response = $this->putJson("/api/ligas/{$user->id}/points");
+        $response = $this->putJson("/api/ligas/{$user->id}/points", [
+            'league_id' => 1,
+        ]);
 
         $response->assertStatus(200);
     }


### PR DESCRIPTION
## 📌 Update LigaController and tests (league_id + weekly points support)

### 🧠 Contexto
Esta PR actualiza la lógica de la Liga para soportar `league_id` en todos los flujos y añade el seguimiento de `points_weekly` además de los puntos totales.

---

## ✨ Cambios principales

### 🟢 LigaController

- Se añade soporte de `league_id` en:
  - `store()`
  - `addPoints()`
- Se inicializan correctamente los campos:
  - `points = 0`
  - `points_weekly = 0`
- Se actualiza el endpoint `ranking()` para incluir:
  - `user_name`
  - `points_weekly`
  - `created_at`
  - `updated_at`
- En `addPoints()`:
  - Se incrementan `points` y `points_weekly`
  - Se devuelve ambos valores en la respuesta
  - Se valida existencia del usuario en la liga

---

### 🟢 Tests

#### LigaAddPointsTest
- Se añade `league_id` en todas las llamadas
- Casos cubiertos:
  - Incremento por defecto de 5 puntos
  - Acumulación de puntos (15 tras 3 llamadas)
  - 404 para usuario inexistente
  - 403 para usuario no inscrito en la liga
- Refactor del test para simplificar estructura

---

#### LigaGetRankingTest
- Se valida el contrato completo del ranking:
  - `position`
  - `user_id`
  - `user_name`
  - `points`
  - `points_weekly`
  - `created_at`
  - `updated_at`
- Se valida:
  - Orden por puntos descendente
  - Posiciones secuenciales
  - Inclusión de usuarios con 0 puntos
  - Empates correctamente numerados

---

#### LigaStubTest
- Mantiene tests básicos de integración:
  - GET `/ligas/ranking`
  - POST `/ligas`
  - PUT `/ligas/{id}/points`

---

## ⚠️ Notas

- `league_id` ahora es obligatorio en todos los endpoints de escritura
- `points_weekly` se incrementa junto con `points`
- `user_name` se almacena en la tabla `ligas` para evitar joins en ranking

---

## 🚀 Resultado

- Soporte multi-liga preparado
- Métricas semanales añadidas
- Contrato de API estabilizado
- Tests alineados con la nueva lógica