### PR TITLE
test: add createTicket error handling test

### DIFF
--- a/frontend/src/api/__tests__/endPointTickets.test.ts
+++ b/frontend/src/api/__tests__/endPointTickets.test.ts
@@ -52,4 +52,9 @@ describe("createTicket", () => {
       }),
     );
   });
+  it("should throw error if request fails", async () => {
+    vi.mocked(axios.post).mockRejectedValue(new Error("Network error"));
+
+    await expect(createTicket(mockPayload)).rejects.toThrow("Network error");
+  });
 });


### PR DESCRIPTION
Adds a dedicated test for createTicket error handling.

This test was separated from PR #517 following review feedback requesting separation of happy path and error handling tests.

Depends on #477 (create ticket implementation).