### PR TITLE
Global ranking display

### DIFF
--- a/frontend/src/components/Leagues/__test__/GlobalRanking.test.tsx
+++ b/frontend/src/components/Leagues/__test__/GlobalRanking.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { GlobalRanking } from "../GlobalRanking";
+import { GlobalRanking } from "../../Leagues/GlobalRanking";
 
 describe("GlobalRanking", () => {
   it("renders the global ranking", () => {

--- a/frontend/src/components/Leagues/__test__/GlobalRanking.test.tsx
+++ b/frontend/src/components/Leagues/__test__/GlobalRanking.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { GlobalRanking } from "../../Leagues/GlobalRanking";
+import { GlobalRanking } from "../../leagues/GlobalRanking";
 
 describe("GlobalRanking", () => {
   it("renders the global ranking", () => {

--- a/frontend/src/components/Leagues/__test__/GlobalRanking.test.tsx
+++ b/frontend/src/components/Leagues/__test__/GlobalRanking.test.tsx
@@ -1,0 +1,22 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GlobalRanking } from "../GlobalRanking";
+
+describe("GlobalRanking", () => {
+  it("renders the global ranking", () => {
+    render(<GlobalRanking />);
+    const container = document.querySelector("article");
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveTextContent("Jordi");
+    expect(container).toHaveTextContent("115");
+  });
+  it("renders the add point component", () => {
+    render(<GlobalRanking />);
+    const form = document.querySelector("form");
+    expect(form).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sumar punts/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/leagues/GlobalRanking.tsx
+++ b/frontend/src/components/leagues/GlobalRanking.tsx
@@ -1,7 +1,52 @@
+import { Ranking } from "../../types/league";
+import { AddLeaguePoints } from "./AddLeaguePoints";
+import { LeagueList } from "./LeagueList";
+
 export const GlobalRanking = () => {
+  const mockData: Ranking[] = [
+    {
+      position: 1,
+      user_id: 101,
+      username: "Jordi",
+      points: 115,
+      points_weekly: 30,
+      status: "Junior developer",
+      language: "React",
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:00Z",
+      league_id: 1,
+    },
+    {
+      position: 2,
+      user_id: 102,
+      username: "Laia",
+      points: 105,
+      points_weekly: 20,
+      status: "Junior developer",
+      language: "React",
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:00Z",
+      league_id: 2,
+    },
+    {
+      position: 3,
+      user_id: 103,
+      username: "Marc",
+      points: 99,
+      points_weekly: 10,
+      status: "Junior developer",
+      language: "React",
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:00Z",
+      league_id: 2,
+    },
+  ];
+
   return (
     <section>
       <h1>Classificació general</h1>
+      <LeagueList standings={mockData} />
+      <AddLeaguePoints />
     </section>
   );
 };


### PR DESCRIPTION
## What
- Assembled `GlobalRanking.tsx` to show both the global ranking and the add points form.
- Added corresponding UI tests.

## Preview:
<img width="1428" height="633" alt="Capture d’écran 2026-05-14 à 16 01 00" src="https://github.com/user-attachments/assets/cdf62364-90c1-4f4c-a846-ce28c845cd33" />

## Related PRs:
 - [#535](https://github.com/IT-Academy-BCN/ita-wiki-monorepo/pull/535): where the data to insert in the ranking (list) component is retrieved from the backend