### PR TITLE
feat: add ApiContributor type and contributor API functions

### DIFF
--- a/frontend/src/api/__tests__/endPointContributors.test.ts
+++ b/frontend/src/api/__tests__/endPointContributors.test.ts
@@ -11,7 +11,15 @@ vi.mock("../../config", () => ({
 
 describe("fetchProjectContributors", () => {
   it("should return contributors on success", async () => {
-    const mockContributors = [{ id: 1, user_id: 101, programming_role: "Frontend Developer", status: "pending", user: { id: 101, name: "Júlia", email: "julia@test.com" } }];
+    const mockContributors = [
+      {
+        id: 1,
+        user_id: 101,
+        programming_role: "Frontend Developer",
+        status: "pending",
+        user: { id: 101, name: "Júlia", email: "julia@test.com" },
+      },
+    ];
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: mockContributors }),
@@ -36,4 +44,3 @@ describe("updateContributorStatus", () => {
     expect(await updateContributorStatus(1, 42, "rejected")).toBe(false);
   });
 });
-

--- a/frontend/src/api/__tests__/endPointContributors.test.ts
+++ b/frontend/src/api/__tests__/endPointContributors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchProjectContributors,
+  updateContributorStatus,
+} from "../endPointContributors";
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:8000",
+  END_POINTS: { codeconnect: { get: "/codeconnect" } },
+}));
+
+describe("fetchProjectContributors", () => {
+  it("should return contributors on success", async () => {
+    const mockContributors = [{ id: 1, user_id: 101, programming_role: "Frontend Developer", status: "pending", user: { id: 101, name: "Júlia", email: "julia@test.com" } }];
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockContributors }),
+    });
+    expect(await fetchProjectContributors(1)).toEqual(mockContributors);
+  });
+
+  it("should return an empty array when response is not ok", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false });
+    expect(await fetchProjectContributors(1)).toEqual([]);
+  });
+});
+
+describe("updateContributorStatus", () => {
+  it("should return true on successful response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: true });
+    expect(await updateContributorStatus(1, 42, "accepted")).toBe(true);
+  });
+
+  it("should return false when response is not ok", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false });
+    expect(await updateContributorStatus(1, 42, "rejected")).toBe(false);
+  });
+});
+

--- a/frontend/src/api/endPointContributors.ts
+++ b/frontend/src/api/endPointContributors.ts
@@ -1,0 +1,41 @@
+import { API_URL, END_POINTS } from "../config";
+import type { ApiContributor } from "../types/codeConnectTypes";
+
+export const fetchProjectContributors = async (
+  projectId: number,
+): Promise<ApiContributor[]> => {
+  const url = `${API_URL}${END_POINTS.codeconnect.get}/${projectId}/contributors`;
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) return [];
+    const data = (await response.json()) as { data: ApiContributor[] };
+    return data.data ?? [];
+  } catch {
+    return [];
+  }
+};
+
+export const updateContributorStatus = async (
+  projectId: number,
+  contributorId: number,
+  status: "accepted" | "rejected",
+): Promise<boolean> => {
+  const token = localStorage.getItem("auth_token");
+  const url = `${API_URL}${END_POINTS.codeconnect.get}/${projectId}/contributors/${contributorId}/status`;
+  try {
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -31,6 +31,7 @@ export interface ApiProjectContributor {
 
 export interface ApiProjectData {
   id: number;
+  user_id: number;
   contributors: ApiProjectContributor[];
   description?: string;
   language_backend: string;
@@ -38,6 +39,18 @@ export interface ApiProjectData {
   roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
+}
+
+export interface ApiContributor {
+  id: number;
+  user_id: number;
+  programming_role: string;
+  status: "pending" | "accepted" | "rejected";
+  user: {
+    id: number;
+    name: string;
+    email: string;
+  };
 }
 
 export interface ApiProjectsResponse {


### PR DESCRIPTION
Data layer needed to support accept/reject contributor requests on project detail.

## Changes

- Add `ApiContributor` interface to `codeConnectTypes.ts`
- Add `user_id` field to `ApiProjectData`
- New `endPointContributors.ts` with `fetchProjectContributors()` and `updateContributorStatus()`
- Tests for both API functions

## Notes
UI layer (PendingRequests component + CodeConnectDetails integration) will be delivered in a follow-up PR that depends on this one.

Part of #506 split.
