### PR TITLE
Remove .env requirement and replace with ENV variable existence

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,7 +25,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY bootstrap ./bootstrap
 COPY public ./public
 COPY src ./src
-COPY .env.dev ./
 COPY  artisan composer.json composer.lock phpunit.xml ./
 RUN mkdir -p storage/app/public
 

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -46,9 +46,6 @@
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
         ],
-        "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",

--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -25,7 +25,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY bootstrap ./bootstrap
 COPY public ./public
 COPY src ./src
-COPY .env.dev ./.env.dev
 COPY  artisan composer.json composer.lock phpunit.xml ./
 
 # Create storage directory structure (since it's not in version control)

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -8,7 +8,9 @@ services:
             - "8000:80"
         volumes:
             - ../src:/var/www/html/src
-            - ../.env.docker:/var/www/html/.env.docker:ro
+        env_file:
+            - path: ./.env
+              required: false
         depends_on:
             - mysql
         networks:

--- a/backend/docker/entrypoint.sh
+++ b/backend/docker/entrypoint.sh
@@ -5,20 +5,15 @@ cd /var/www/html
 
 echo "=== ENTRYPOINT START ==="
 
-if [ ! -f .env ]; then
-    echo "[INFO] .env not found, using .env.dev as base"
-    if [ -f .env.dev ]; then
-        cp .env.dev .env
-    else
-        echo "[ERROR] .env.dev not found in /var/www/html"
-        exit 1
-    fi
+if [[ ! -f ".env" ]]; then
+    touch .env
 fi
 
-echo "Loading environment variables from .env..."
-if [ -f .env ]; then
-    export $(grep -v '^[#[:space:]]' .env | xargs)
+if [[ -z "$APP_ENV" ]]; then
+    echo "[ERROR] APP_ENV is not defined"
+    exit 1
 fi
+
 
 echo "APP_ENV is set to: '$APP_ENV'"
 
@@ -43,9 +38,6 @@ if [ -z "$APP_KEY" ]; then
     echo "APP_KEY is empty or not set. Generating application key..."
     php artisan key:generate --force
 
-        if [ -f .env ]; then
-        export $(grep -v '^[#[:space:]]' .env | xargs)
-    fi
 else
     echo "APP_KEY is already set. Skipping key:generate."
 fi


### PR DESCRIPTION
For AWS we cannot always have a check for the .env file, as env variables will come directly.

Objectives:
- Remove any requirements for .env files existing
- Still allow current development workflow using .env files
- Ensure we support direct ENV variable injections from AWS