### PR TITLE
Style ranking/league list element as per figma mockup

### DIFF
--- a/frontend/src/components/leagues-ranking/LeagueList/LeagueList.tsx
+++ b/frontend/src/components/leagues-ranking/LeagueList/LeagueList.tsx
@@ -1,21 +1,35 @@
 import type { LeagueListProps } from "../../../types/league";
 
 export const LeagueList = ({ standings }: LeagueListProps) => {
+  const getStyle = (index: number) => {
+    const base =
+      "grid grid-cols-6 border-b last:border-b-0 border-gray-400 px-4 py-4 text-sm text-center text-slate-950";
+
+    const color =
+      standings.length > 3 && index < 3
+        ? "bg-green-100"
+        : standings.length > 6 && index >= standings.length - 3
+          ? "bg-red-100"
+          : "";
+
+    return `${base} ${color}`.trim();
+  };
+
   return (
     <article className="w-full max-w-3xl">
-      <div className="w-full">
-        <div className="grid grid-cols-6 border-b-2 border-pink-600 px-4 py-3 text-sm font-bold text-slate-950">
-          <div>Posició</div>
-          <div>Nom</div>
-          <div className="col-span-2">Estatus</div>
-          <div>Llenguatge</div>
-          <div>Punts</div>
-        </div>
+      <div className="grid grid-cols-6 px-4 py-3 text-sm text-center font-bold text-slate-950">
+        <div>Posició</div>
+        <div>Nom</div>
+        <div className="col-span-2">Estatus</div>
+        <div>Llenguatge</div>
+        <div>Punts</div>
+      </div>
 
+      <div className="border border-gray-400 bg-white rounded-xl overflow-hidden">
         {standings.map((standing, index) => (
           <div
             key={standing.username}
-            className="grid grid-cols-6 border-b border-slate-300 px-4 py-4 text-sm text-slate-950"
+            className={getStyle(index)}
             data-testid={`league-position-${index + 1}`}
           >
             <div>{index + 1}</div>

--- a/frontend/src/components/leagues-ranking/__test__/LeagueList.test.tsx
+++ b/frontend/src/components/leagues-ranking/__test__/LeagueList.test.tsx
@@ -4,22 +4,21 @@ import { describe, expect, it } from "vitest";
 
 import { LeagueList } from "../LeagueList/LeagueList";
 
-const mockStandings = [
-  {
-    position: 1,
-    user_id: 101,
-    username: "Júlia",
-    points: 94,
+export const createMockStandings = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    position: index + 1,
+    user_id: 101 + index,
+    username: `Júlia ${index > 0 ? index : ""}`,
+    points: 94 - index * 2,
     status: "Junior developer",
     language: "React",
     created_at: "2026-04-24T00:00:00Z",
     updated_at: "2026-04-24T00:00:00Z",
-  },
-];
+  }));
 
 describe("LeagueList", () => {
   it("renders the column headers", () => {
-    render(<LeagueList standings={mockStandings} />);
+    render(<LeagueList standings={createMockStandings(1)} />);
 
     expect(screen.getByText("Posició")).toBeInTheDocument();
     expect(screen.getByText("Nom")).toBeInTheDocument();
@@ -29,7 +28,7 @@ describe("LeagueList", () => {
   });
 
   it("renders all standings correctly", () => {
-    render(<LeagueList standings={mockStandings} />);
+    render(<LeagueList standings={createMockStandings(1)} />);
 
     expect(screen.getByText("Júlia")).toBeInTheDocument();
     expect(screen.getByText("94")).toBeInTheDocument();
@@ -43,5 +42,25 @@ describe("LeagueList", () => {
     render(<LeagueList standings={[]} />);
 
     expect(screen.queryByTestId("league-position-1")).not.toBeInTheDocument();
+  });
+
+  it("applies green background to the top 3 when there are more than 3 participants", () => {
+    render(<LeagueList standings={createMockStandings(4)} />);
+    expect(screen.getByTestId("league-position-1")).toHaveClass("bg-green-100");
+    expect(screen.getByTestId("league-position-2")).toHaveClass("bg-green-100");
+    expect(screen.getByTestId("league-position-3")).toHaveClass("bg-green-100");
+    expect(screen.getByTestId("league-position-4")).not.toHaveClass(
+      "bg-green-100",
+    );
+  });
+
+  it("applies red background to the last 3 when there are more than 6 participants", () => {
+    render(<LeagueList standings={createMockStandings(7)} />);
+    expect(screen.getByTestId("league-position-5")).toHaveClass("bg-red-100");
+    expect(screen.getByTestId("league-position-6")).toHaveClass("bg-red-100");
+    expect(screen.getByTestId("league-position-7")).toHaveClass("bg-red-100");
+    expect(screen.getByTestId("league-position-4")).not.toHaveClass(
+      "bg-red-100",
+    );
   });
 });


### PR DESCRIPTION
### This is an additional work done on the league list component.

**Changes:**
 - restyled the list as per figma mockup
 - added corresponding UI tests
 
**Preview:**
<table>
  <tr>
    <th align="center">
      <strong>Before</strong><br/>
    </th>
    <th align="center">
      <strong>Now</strong><br/>
    </th>
  </tr>
<tr>
<td>
<img width="846" height="351" alt="Capture d’écran 2026-05-18 à 13 23 00" src="https://github.com/user-attachments/assets/d9a437ff-681d-4a5f-90c2-ad2ff37eeb26" />
</td>
<td>
<img width="841" height="342" alt="Capture d’écran 2026-05-18 à 13 22 43" src="https://github.com/user-attachments/assets/7c0ec2a4-00d9-4b12-b5f3-a6c5144be374" />
</td>
</tr>
</table>

NB: conditional colors for top 3 and last 3 are included in this PR, even though not visible in the preview above. The behaviour is verified in the tests.