### PR TITLE
Leagues - added correct fetch for league rankings

### DIFF
--- a/frontend/src/api/__tests__/endPointLeagues.test.ts
+++ b/frontend/src/api/__tests__/endPointLeagues.test.ts
@@ -25,19 +25,18 @@ describe("fetchLeagueRanking", () => {
   });
 
   it("Should fetch the league rankings", async () => {
-    const mockResponse: LigaResponse = [
-      {
-        "1": [
-          {
-            position: 1,
-            user_id: 7,
-            username: "ckoelpin",
-            points_weekly: 99,
-            league_id: 1,
-          },
-        ],
-      },
-    ];
+    const mockResponse: LigaResponse = {
+      "1": [
+        {
+          position: 1,
+          user_id: 7,
+          username: "ckoelpin",
+          points_weekly: 99,
+          league_id: 1,
+        },
+      ],
+    };
+
     fetchMock.mockResolvedValueOnce({
       json: async () => mockResponse,
       ok: true,

--- a/frontend/src/api/__tests__/endPointLeagues.test.ts
+++ b/frontend/src/api/__tests__/endPointLeagues.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LigaResponse } from "../../types/league";
+import { fetchLeagueRanking } from "../endPointLeagues";
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:8000",
+  END_POINTS: {
+    leagues: {
+      getWeekly: "/ligas",
+    },
+  },
+}));
+
+const fetchMock = vi.fn();
+
+describe("fetchLeagueRanking", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("Should fetch the league rankings", async () => {
+    const mockResponse: LigaResponse = [
+      {
+        "1": [
+          {
+            position: 1,
+            user_id: 7,
+            username: "ckoelpin",
+            points_weekly: 99,
+            league_id: 1,
+          },
+        ],
+      },
+    ];
+    fetchMock.mockResolvedValueOnce({
+      json: async () => mockResponse,
+      ok: true,
+    });
+
+    const result = await fetchLeagueRanking();
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:8000/ligas", {
+      signal: undefined,
+    });
+    expect(result).toEqual(mockResponse);
+  });
+});

--- a/frontend/src/api/__tests__/endPointLeagues.test.ts
+++ b/frontend/src/api/__tests__/endPointLeagues.test.ts
@@ -4,7 +4,7 @@ import { LigaResponse } from "../../types/league";
 import { fetchLeagueRanking } from "../endPointLeagues";
 
 vi.mock("../../config", () => ({
-  API_URL: "http://localhost:8000",
+  API_URL: "http://localhost/api",
   END_POINTS: {
     leagues: {
       getWeekly: "/ligas",
@@ -44,7 +44,7 @@ describe("fetchLeagueRanking", () => {
 
     const result = await fetchLeagueRanking();
 
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:8000/ligas", {
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost/api/ligas", {
       signal: undefined,
     });
     expect(result).toEqual(mockResponse);

--- a/frontend/src/api/endPointLeagues.ts
+++ b/frontend/src/api/endPointLeagues.ts
@@ -1,10 +1,28 @@
 import { API_URL, END_POINTS } from "../config";
+import { LigaResponse } from "../types/league";
 
 export const fetchGlobalRanking = async (signal?: AbortSignal) => {
   const url = `${API_URL}${END_POINTS.leagues.get}`;
   try {
     const response = await fetch(url, { signal });
     if (!response.ok) throw new Error("Failed to fetch ranking");
+    const data = await response.json();
+    return data;
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError")
+      throw error;
+    console.error(error);
+    throw error;
+  }
+};
+
+export const fetchLeagueRanking = async (
+  signal?: AbortSignal,
+): Promise<LigaResponse> => {
+  const url = `${API_URL}${END_POINTS.leagues.getWeekly}`;
+  try {
+    const response = await fetch(url, { signal });
+    if (!response.ok) throw new Error("Failed to fetch leagues");
     const data = await response.json();
     return data;
   } catch (error: unknown) {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -67,6 +67,7 @@ const END_POINTS = {
   },
   leagues: {
     get: "ligas/ranking" as EndPoints,
+    getWeekly: "ligas" as EndPoints,
     post: "ligas" as EndPoints,
     addPoints: "ligas" as EndPoints,
   },

--- a/frontend/src/types/league.ts
+++ b/frontend/src/types/league.ts
@@ -6,7 +6,7 @@ export type Liga = {
   league_id: number;
 };
 
-export type LigaResponse = { [key: string]: Liga[] }[];
+export type LigaResponse = { [key: string]: Liga[] };
 
 export type LeagueListProps = {
   standings: Omit<Ranking, "points_weekly" | "league_id">[];

--- a/frontend/src/types/league.ts
+++ b/frontend/src/types/league.ts
@@ -2,13 +2,11 @@ export type Liga = {
   position: number;
   user_id: number;
   username: string;
-  points: number;
   points_weekly: number;
-  created_at: string;
-  updated_at: string;
+  league_id: number;
 };
 
-export type LigaResponse = Liga[];
+export type LigaResponse = { [key: string]: Liga[] }[];
 
 export type LeagueListProps = {
   standings: Omit<Ranking, "points_weekly" | "league_id">[];


### PR DESCRIPTION
### Added dedicated fetch for league ranking

**Changes:**
- Added missing fetch function to retrieve the league specific franking, since there is a dedicated endpoint for it
- Update the Liga type to match what's actually being returned
- Added corresponding test

**NB:** the PR is over > 50 lines because 52 lines are basically the single test for the fetch function.