### PR TITLE
Create the pending collaboration requests section

### DIFF
--- a/frontend/src/components/code-connect/pendingRequests/PendingRequest.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/PendingRequest.tsx
@@ -1,0 +1,11 @@
+import type { ApiContributor } from "../../../types/codeConnectTypes";
+
+interface PendingRequestProps {
+  contributor: ApiContributor;
+}
+
+const PendingRequest = (_: PendingRequestProps) => {
+  return null;
+};
+
+export default PendingRequest;

--- a/frontend/src/components/code-connect/pendingRequests/PendingRequest.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/PendingRequest.tsx
@@ -4,7 +4,7 @@ interface PendingRequestProps {
   contributor: ApiContributor;
 }
 
-const PendingRequest = (_: PendingRequestProps) => {
+const PendingRequest = (_props: PendingRequestProps) => {
   return null;
 };
 

--- a/frontend/src/components/code-connect/pendingRequests/PendingRequest.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/PendingRequest.tsx
@@ -1,11 +1,10 @@
+import type { FC } from "react";
 import type { ApiContributor } from "../../../types/codeConnectTypes";
 
 interface PendingRequestProps {
   contributor: ApiContributor;
 }
 
-const PendingRequest = (_props: PendingRequestProps) => {
-  return null;
-};
+const PendingRequest: FC<PendingRequestProps> = () => null;
 
 export default PendingRequest;

--- a/frontend/src/components/code-connect/pendingRequests/PendingRequestList.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/PendingRequestList.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { fetchProjectContributors } from "../../../api/endPointContributors";
+import type { ApiContributor } from "../../../types/codeConnectTypes";
+import PendingRequest from "./PendingRequest";
+
+interface PendingRequestListProps {
+  projectId: number;
+}
+
+const PendingRequestList = ({ projectId }: PendingRequestListProps) => {
+  const [pending, setPending] = useState<ApiContributor[]>([]);
+
+  useEffect(() => {
+    fetchProjectContributors(projectId).then((contributors) => {
+      setPending(contributors.filter((c) => c.status === "pending"));
+    });
+  }, [projectId]);
+
+  if (pending.length === 0) return null;
+
+  return (
+    <div className="mb-8 p-4 bg-pink-50 rounded-lg">
+      <h3 className="text-[22px] font-extrabold mb-5">
+        Peticions de col·laboració:
+      </h3>
+      <ul className="flex flex-col gap-3">
+        {pending.map((contributor) => (
+          <PendingRequest key={contributor.id} contributor={contributor} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PendingRequestList;

--- a/frontend/src/components/code-connect/pendingRequests/PendingRequestList.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/PendingRequestList.tsx
@@ -20,7 +20,7 @@ const PendingRequestList = ({ projectId }: PendingRequestListProps) => {
 
   return (
     <div className="mb-8 p-4 bg-pink-50 rounded-lg">
-      <h3 className="text-[22px] font-extrabold mb-5">
+      <h3 className="text-[16px] font-extrabold mb-5">
         Peticions de col·laboració:
       </h3>
       <ul className="flex flex-col gap-3">

--- a/frontend/src/components/code-connect/pendingRequests/__test__/PendingRequestList.test.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/__test__/PendingRequestList.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import PendingRequestList from "../PendingRequestList";
+import * as endPointContributors from "../../../../api/endPointContributors";
+import type { ApiContributor } from "../../../../types/codeConnectTypes";
+
+vi.mock("../../../../api/endPointContributors");
+
+vi.mock("../PendingRequest", () => ({ default: () => null }));
+
+const pendingContributor: ApiContributor = {
+  id: 1,
+  user_id: 200,
+  programming_role: "Frontend Developer",
+  status: "pending",
+  user: { id: 200, name: "Anna", email: "anna@test.com" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PendingRequestList", () => {
+  it("does not render when there are no pending requests", async () => {
+    vi.spyOn(endPointContributors, "fetchProjectContributors").mockResolvedValue([]);
+
+    const { container } = render(<PendingRequestList projectId={1} />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders the section when there are pending requests", async () => {
+    vi.spyOn(endPointContributors, "fetchProjectContributors").mockResolvedValue([pendingContributor]);
+
+    render(<PendingRequestList projectId={1} />);
+
+    expect(await screen.findByText("Peticions de col·laboració:")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/code-connect/pendingRequests/__test__/PendingRequestList.test.tsx
+++ b/frontend/src/components/code-connect/pendingRequests/__test__/PendingRequestList.test.tsx
@@ -23,7 +23,10 @@ beforeEach(() => {
 
 describe("PendingRequestList", () => {
   it("does not render when there are no pending requests", async () => {
-    vi.spyOn(endPointContributors, "fetchProjectContributors").mockResolvedValue([]);
+    vi.spyOn(
+      endPointContributors,
+      "fetchProjectContributors",
+    ).mockResolvedValue([]);
 
     const { container } = render(<PendingRequestList projectId={1} />);
 
@@ -33,7 +36,10 @@ describe("PendingRequestList", () => {
   });
 
   it("renders the section when there are pending requests", async () => {
-    vi.spyOn(endPointContributors, "fetchProjectContributors").mockResolvedValue([pendingContributor]);
+    vi.spyOn(
+      endPointContributors,
+      "fetchProjectContributors",
+    ).mockResolvedValue([pendingContributor]);
 
     render(<PendingRequestList projectId={1} />);
 

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router";
+import PendingRequestList from "../components/code-connect/pendingRequests/PendingRequestList";
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
@@ -33,6 +34,7 @@ const CodeConnectDetails = () => {
                   "No s'ha pogut carregar el títol del projecte."}
               </h2>
 
+              <PendingRequestList projectId={codeConnectProject.data.id} />
               <h3 className="text-[22px] font-extrabold mb-5">Descripció:</h3>
               <p className="text-[16px] mb-10">
                 {codeConnectProject.data?.description ||


### PR DESCRIPTION
### **Summary**

- Adds the UI scaffold for the pending collaboration requests section on the project detail page.

- `PendingRequestList` fetches contributors for the project and filters those with `pending` status. If there are no pending requests, the section is not rendered. Each pending contributor is passed to an empty `PendingRequest` component (data rendering comes in the next PR).

- `PendingRequestList` is integrated in `CodeConnectDetails` above the description section.

<img width="941" height="310" alt="Captura de pantalla 2026-05-21 a las 9 09 33" src="https://github.com/user-attachments/assets/d126c09f-b6da-450f-b16a-f87b31ee49b7" />

**Note**: The line count exceeds 50 due to the test file (42 lines).                                                                                  
The component logic across `PendingRequest.tsx` and `PendingRequestList.tsx` totals 45 lines.

### **Test plan** 

- [x] PendingRequestList does not render when there are no pending requests
- [x] PendingRequestList renders "Peticions de col·laboració" section when there are pending requests 
- [x] npm run test -- PendingRequestList passes