### PR TITLE
Add creator role to ticket index response for admin users

### DIFF
--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -30,7 +30,7 @@ class TicketController extends Controller
 
         $tickets = $query->get();
 
-        if (auth()->user()->hasAnyRole(['admin'])) {
+        if (auth()->user()->hasAnyRole(['admin' , 'superadmin'])) {
             $tickets->each(function ($ticket) {
                 if ($ticket->codeConnect) {
                     $ticket->codeConnect->role = $ticket->codeConnect->getRoleName();

--- a/backend/src/app/Http/Controllers/Tickets/TicketController.php
+++ b/backend/src/app/Http/Controllers/Tickets/TicketController.php
@@ -28,9 +28,20 @@ class TicketController extends Controller
             });
         }
 
+        $tickets = $query->get();
+
+        if (auth()->user()->hasAnyRole(['admin'])) {
+            $tickets->each(function ($ticket) {
+                if ($ticket->codeConnect) {
+                    $ticket->codeConnect->role = $ticket->codeConnect->getRoleName();
+                    $ticket->codeConnect->makeHidden('roles');
+                }
+            });
+        }
+
         return response()->json([
             'success' => true,
-            'data' => $query->get()
+            'data' => $tickets
         ]);
     }
 

--- a/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
@@ -820,5 +820,32 @@ class TicketControllerTest extends TestCase{
             'closed_at' => null,
         ]);
     }
+
+    /** @test */
+    public function admin_can_see_creator_role_in_ticket_list(): void
+    {
+        $admin = $this->authenticateUserWithRole('admin');
+        $creator = User::factory()->create();
+        $creator->assignRole('student');
+        Ticket::factory()->create(['code_connect_id' => $creator->id]);
+
+        $response = $this->getJson('/api/tickets');
+
+        $response->assertStatus(200);
+        $this->assertArrayHasKey('role', $response->json('data.0.code_connect'));
+        $this->assertEquals('student', $response->json('data.0.code_connect.role'));
+    }
+
+    /** @test */
+    public function non_admin_cannot_see_creator_role_in_ticket_list(): void
+    {
+        $student = $this->authenticateUserWithRole('student');
+        Ticket::factory()->create(['code_connect_id' => $student->id]);
+
+        $response = $this->getJson('/api/tickets');
+
+        $response->assertStatus(200);
+        $this->assertArrayNotHasKey('role', $response->json('data.0.code_connect'));
+    }
 }
 ?>

--- a/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
+++ b/backend/src/tests/Feature/ReportingTickets/TicketControllerTest.php
@@ -847,5 +847,19 @@ class TicketControllerTest extends TestCase{
         $response->assertStatus(200);
         $this->assertArrayNotHasKey('role', $response->json('data.0.code_connect'));
     }
+
+    /** @test */
+    public function superadmin_can_see_creator_role_in_ticket_list(): void{
+        $superadmin = $this->authenticateUserWithRole('superadmin');
+        $creator = User::factory()->create();
+        $creator->assignRole('student');
+        Ticket::factory()->create(['code_connect_id' => $creator->id]);
+
+        $response = $this->getJson('/api/tickets');
+
+        $response->assertStatus(200);
+        $this->assertArrayHasKey('role', $response->json('data.0.code_connect'));
+        $this->assertEquals('student', $response->json('data.0.code_connect.role'));
+    }
 }
 ?>


### PR DESCRIPTION
When an authenticated user with the admin role retrieves the ticket list, the response now includes the role field of the ticket creator inside the code_connect object. Non-admin users will not see this field.

The admin role is being used as a temporary replacement for the developer role, which doesn't exist yet. Once the developer role is created, it will replace admin here. The superadmin is intentionally excluded from this feature for now. This was agreed with the team.