### PR TITLE
Conditionally display the add point component

### DIFF
--- a/frontend/src/components/leagues-ranking/GlobalRanking/GlobalRanking.tsx
+++ b/frontend/src/components/leagues-ranking/GlobalRanking/GlobalRanking.tsx
@@ -1,14 +1,18 @@
 import { useGlobalRanking } from "../../../hooks/useGlobalRanking";
+import { useUser } from "../../../hooks/useUser";
 import { AddLeaguePoints } from "../AddLeaguePoints/AddLeaguePoints";
 import { LeagueList } from "../LeagueList/LeagueList";
 
 export const GlobalRanking = () => {
+  const { user } = useUser();
   const { globalRanking } = useGlobalRanking();
 
   return (
     <section>
       <LeagueList standings={globalRanking} />
-      <AddLeaguePoints users={globalRanking} />
+      {user?.role && user.role !== "student" && (
+        <AddLeaguePoints users={globalRanking} />
+      )}
     </section>
   );
 };

--- a/frontend/src/components/leagues-ranking/__test__/GlobalRanking.test.tsx
+++ b/frontend/src/components/leagues-ranking/__test__/GlobalRanking.test.tsx
@@ -1,7 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchGlobalRanking } from "../../../api/endPointLeagues";
+import { useUserContext } from "../../../context/UserContext";
+import { TypUserRole } from "../../../types";
 import { GlobalRanking } from "../GlobalRanking/GlobalRanking";
 
 vi.mock("../../../api/endPointLeagues", () => ({
@@ -40,6 +42,31 @@ vi.mock("../AddLeaguePoints/AddLeaguePoints", () => ({
   ),
 }));
 
+vi.mock("../../../context/UserContext");
+
+const mockUserContext = (role: TypUserRole) => {
+  vi.mocked(useUserContext).mockReturnValue({
+    user: {
+      id: 1,
+      github_user_name: "test-user",
+      github_id: 123,
+      name: "Test User",
+      email: "test@example.com",
+      password: "",
+      role: role,
+    },
+    isAuthenticated: true,
+    setUser: vi.fn(),
+    signOut: vi.fn(),
+    signIn: vi.fn(),
+    saveUser: vi.fn(),
+    error: null,
+    setError: vi.fn(),
+    loading: false,
+    setIsLoading: vi.fn(),
+  });
+};
+
 const mockRanking = [
   {
     position: 1,
@@ -56,20 +83,23 @@ const mockRanking = [
 ];
 
 describe("GlobalRanking", () => {
+  beforeEach(() => {
+    mockUserContext("student");
+  });
   it("renders the league list after fetch", async () => {
     vi.mocked(fetchGlobalRanking).mockResolvedValue(mockRanking);
-
     render(<GlobalRanking />);
 
     await waitFor(() => {
       expect(screen.getByText("Posició")).toBeInTheDocument();
     });
 
-    expect(screen.getAllByText("Júlia")).toHaveLength(2);
+    expect(screen.getAllByText("Júlia")).toHaveLength(1);
     expect(screen.getByText("94")).toBeInTheDocument();
   });
 
-  it("renders AddLeaguePoints", () => {
+  it("renders AddLeaguePoints for mentors", () => {
+    mockUserContext("mentor");
     vi.mocked(fetchGlobalRanking).mockResolvedValue([]);
 
     render(<GlobalRanking />);
@@ -79,7 +109,8 @@ describe("GlobalRanking", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders AddLeaguePoints with ranking users", async () => {
+  it("renders AddLeaguePoints with ranking users (for mentors)", async () => {
+    mockUserContext("mentor");
     vi.mocked(fetchGlobalRanking).mockResolvedValue(mockRanking);
 
     render(<GlobalRanking />);
@@ -95,17 +126,6 @@ describe("GlobalRanking", () => {
 
   it("renders without crashing on fetch error", () => {
     vi.mocked(fetchGlobalRanking).mockResolvedValue(new Error("fail"));
-
     expect(() => render(<GlobalRanking />)).not.toThrow();
-  });
-
-  it("renders the add point component", () => {
-    vi.mocked(fetchGlobalRanking).mockResolvedValue(mockRanking);
-
-    render(<GlobalRanking />);
-
-    expect(
-      screen.getByRole("form", { name: /add league points/i }),
-    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Changes:**
The `AddLeaguePoints` component is restricted to users with Mentor, Admin, or Superadmin roles. This serves as a frontend filtering layer, while proper authorization is enforced on the backend.