### PR TITLE
feat(#645): add start_date field to project creation form

### DIFF
--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -149,7 +149,7 @@ const FormCreate = () => {
       dev_back_number: formData.dev_back_number,
       time_duration: getTimeDuration(formData.time, formData.unitTime),
       limit_date_inscription: formData.limit_date_inscription,
-      ...(formData.start_date && { start_date: formData.start_date }),
+      start_date: formData.start_date,
     };
 
     try {

--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -31,6 +31,7 @@ const FormCreate = () => {
     time: 0,
     unitTime: "",
     limit_date_inscription: "",
+    start_date: "",
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [roadmap, setRoadmap] = useState<Task[]>([]);
@@ -61,7 +62,7 @@ const FormCreate = () => {
   };
 
   const handleDeadLine = (
-    field: keyof Pick<IntCodeConnect, "limit_date_inscription">,
+    field: keyof Pick<IntCodeConnect, "limit_date_inscription" | "start_date">,
     value: string,
   ) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
@@ -79,6 +80,7 @@ const FormCreate = () => {
       time,
       unitTime,
       limit_date_inscription,
+      start_date,
     } = formData;
 
     if (!language_frontend) {
@@ -108,7 +110,8 @@ const FormCreate = () => {
       dev_back_number <= 0 ||
       !time ||
       !unitTime ||
-      !limit_date_inscription
+      !limit_date_inscription ||
+      !start_date
     ) {
       toast.error("Completa tots els camps obligatoris.");
       return false;
@@ -146,6 +149,7 @@ const FormCreate = () => {
       dev_back_number: formData.dev_back_number,
       time_duration: getTimeDuration(formData.time, formData.unitTime),
       limit_date_inscription: formData.limit_date_inscription,
+      ...(formData.start_date && { start_date: formData.start_date }),
     };
 
     try {
@@ -331,6 +335,24 @@ const FormCreate = () => {
             onChange={(e) =>
               handleDeadLine("limit_date_inscription", e.target.value)
             }
+            min={getMinDeadline()}
+          />
+        </div>
+      </div>
+
+      <div className="lg:w-2/3 my-4">
+        <div className="grid gap-4 lg:grid-cols-3 items-center">
+          <label htmlFor="start_date" className="block font-medium">
+            Data d'inici del projecte *
+          </label>
+          <input
+            id="start_date"
+            className="invalid:text-gray-200 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-[#B91879] focus:border-[#B91879] rounded-lg py-2 px-4"
+            type="date"
+            value={formData.start_date || ""}
+            required
+            disabled={isSubmitting}
+            onChange={(e) => handleDeadLine("start_date", e.target.value)}
             min={getMinDeadline()}
           />
         </div>

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -104,6 +104,11 @@ const fillCompleteForm = async (user: ReturnType<typeof userEvent.setup>) => {
   ) as HTMLInputElement;
   await user.type(devsBackInput, "2");
 
+  const startDateInput = screen.getByLabelText(
+    /data d'inici del projecte/i,
+  ) as HTMLInputElement;
+  await user.type(startDateInput, "2025-12-01");
+
   await waitFor(() => {
     expect(titleInput.value).toBe("Test Project");
     expect(descriptionTextarea.value).toBe("Test description");
@@ -414,6 +419,31 @@ describe("FormCreateCodeConnect", () => {
       expect(reactRadio).toHaveAttribute("value", "React");
       const form = reactRadio.closest("form");
       expect(form).toHaveFormValues({ language_frontend: "React" });
+    });
+
+    it("should render start_date input and include it in payload", async () => {
+      const user = userEvent.setup();
+      mockCreateCodeConnect.mockResolvedValueOnce({});
+      renderWithRouter(<FormCreateCodeConnect />);
+
+      expect(
+        screen.getByLabelText(/data d'inici del projecte/i),
+      ).toBeInTheDocument();
+
+      await fillCompleteForm(user);
+      const form = screen
+        .getByRole("textbox", { name: /títol/i })
+        .closest("form");
+      if (!form) throw new Error("Form not found");
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(mockCreateCodeConnect).toHaveBeenCalledWith(
+          expect.objectContaining({
+            start_date: "2025-12-01",
+          }),
+        );
+      });
     });
 
     it("should show placeholder '0' and empty value when number inputs are at default", () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -60,7 +60,7 @@ export interface IntCodeConnect {
   unitTime: string;
   time_duration: string;
   limit_date_inscription: string;
-  start_date?: string;
+  start_date: string;
 }
 
 export type TypTechnologyResource =

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -60,6 +60,7 @@ export interface IntCodeConnect {
   unitTime: string;
   time_duration: string;
   limit_date_inscription: string;
+  start_date?: string;
 }
 
 export type TypTechnologyResource =


### PR DESCRIPTION
Adds start_date input field to the project creation form (FormCreate.tsx).

- Add start_date field to form state
- Register start_date in handleDeadLine handler
- Include start_date in API request payload
- Add start_date to form validation
- Test: renders start_date input and includes it in payload

Closes #645