### PR TITLE
fix(#614): fix join project endpoint URL

### DIFF
--- a/frontend/src/api/__tests__/endPointJoinProject.test.ts
+++ b/frontend/src/api/__tests__/endPointJoinProject.test.ts
@@ -63,15 +63,15 @@ describe("endPointJoinProject - joinProject", () => {
   });
 
   it("calls the correct endpoint URL", async () => {
-  const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
-    ok: true,
-    status: 200,
-    json: async () => ({}),
-  } as unknown as Response);
-  await joinProject(listProjectId, "Backend Developer");
-  expect(fetchSpy).toHaveBeenCalledWith(
-    expect.stringContaining(`codeconnect/${listProjectId}/join`),
-    expect.any(Object),
-  );
-});
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as unknown as Response);
+    await joinProject(listProjectId, "Backend Developer");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`codeconnect/${listProjectId}/join`),
+      expect.any(Object),
+    );
+  });
 });

--- a/frontend/src/api/__tests__/endPointJoinProject.test.ts
+++ b/frontend/src/api/__tests__/endPointJoinProject.test.ts
@@ -61,4 +61,17 @@ describe("endPointJoinProject - joinProject", () => {
       joinProject(listProjectId, "Backend Developer"),
     ).rejects.toThrow("Network error");
   });
+
+  it("calls the correct endpoint URL", async () => {
+  const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+  } as unknown as Response);
+  await joinProject(listProjectId, "Backend Developer");
+  expect(fetchSpy).toHaveBeenCalledWith(
+    expect.stringContaining(`codeconnect/${listProjectId}/join`),
+    expect.any(Object),
+  );
+});
 });

--- a/frontend/src/api/endPointJoinProject.ts
+++ b/frontend/src/api/endPointJoinProject.ts
@@ -6,7 +6,7 @@ export async function joinProject(
   listProjectId: number,
   programmingRole: ProgrammingRole,
 ): Promise<unknown | null> {
-  const url = `${API_URL}listsProject/${listProjectId}/contributors`;
+  const url = `${API_URL}codeconnect/${listProjectId}/join`;
 
   const response = await fetch(url, {
     method: "POST",


### PR DESCRIPTION
Fixes the wrong URL in endPointJoinProject.ts.

- listsProject/${id}/contributors → codeconnect/${id}/join
- Add test verifying the correct endpoint URL is called

Closes #614