### PR TITLE
Leagues - implemented a button for each scoring activity

### DIFF
--- a/frontend/src/components/leagues-ranking/AddLeaguePoints/AddLeaguePoints.tsx
+++ b/frontend/src/components/leagues-ranking/AddLeaguePoints/AddLeaguePoints.tsx
@@ -16,8 +16,9 @@ export const AddLeaguePoints = ({
   users,
 }: AddLeaguePointsProps): JSX.Element => {
   const [selectedUsername, setSelectedUsername] = useState<string>("");
+  const [addedPoints, setAddedPoints] = useState<number | null>(null);
 
-  const { addPoints, error, isLoading } = useAddLeaguePoints({
+  const { addPoints, error, isLoading, pointSystem } = useAddLeaguePoints({
     addLeaguePoints,
   });
 
@@ -26,17 +27,19 @@ export const AddLeaguePoints = ({
   ): Promise<void> => {
     event.preventDefault();
 
-    if (!selectedUsername) {
+    if (!selectedUsername || !addedPoints) {
       return;
     }
 
-    await addPoints(Number(selectedUsername));
+    await addPoints(Number(selectedUsername), addedPoints);
     setSelectedUsername("");
+    setAddedPoints(null);
   };
 
   return (
     <form className="mt-8" onSubmit={handleSubmit}>
-      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+      <h1>Afegir punts</h1>
+      <div className="flex gap-3 md:items-center">
         <select
           className="min-h-[40px] border border-gray-600 px-3 py-2 text-xs uppercase text-gray-700 focus:border-[#B91879] focus:outline-none focus:ring-1 focus:ring-[#B91879]"
           id="league-username"
@@ -53,13 +56,17 @@ export const AddLeaguePoints = ({
           ))}
         </select>
 
-        <button
-          className="w-fit bg-[#B91879] px-5 py-3 text-xs font-bold uppercase text-white hover:shadow-md disabled:cursor-not-allowed"
-          disabled={!selectedUsername || isLoading}
-          type="submit"
-        >
-          {isLoading ? "Sumant..." : "Sumar punts"}
-        </button>
+        {pointSystem.map((item, index) => (
+          <button
+            key={index}
+            className="flex-1 bg-[#B91879] px-5 py-3 text-xs font-bold uppercase text-white hover:shadow-md disabled:cursor-not-allowed"
+            disabled={!selectedUsername || isLoading}
+            type="submit"
+            onClick={() => setAddedPoints(item.points)}
+          >
+            {isLoading ? "Sumant..." : item.activity}
+          </button>
+        ))}
       </div>
 
       {error && <p>{error}</p>}

--- a/frontend/src/components/leagues-ranking/__test__/AddLeaguePoints.test.tsx
+++ b/frontend/src/components/leagues-ranking/__test__/AddLeaguePoints.test.tsx
@@ -6,6 +6,20 @@ import { describe, expect, it } from "vitest";
 import { AddLeaguePoints } from "../AddLeaguePoints/AddLeaguePoints";
 
 describe("AddLeaguePoints", () => {
+  it("shows a button for each scoring activity", () => {
+    render(
+      <AddLeaguePoints
+        users={[
+          {
+            user_id: 1,
+            username: "Jordi",
+          },
+        ]}
+      />,
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+  });
   it("enables the submit button when a username is selected", async () => {
     const user = userEvent.setup();
 
@@ -21,13 +35,16 @@ describe("AddLeaguePoints", () => {
     );
 
     const select = screen.getByRole("combobox");
-    const button = screen.getByRole("button", { name: "Sumar punts" });
-
-    expect(button).toBeDisabled();
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((button) => {
+      expect(button).toBeDisabled();
+    });
 
     await user.selectOptions(select, "1");
-
     expect(select).toHaveValue("1");
-    expect(button).toBeEnabled();
+
+    buttons.forEach((button) => {
+      expect(button).toBeEnabled();
+    });
   });
 });

--- a/frontend/src/hooks/useAddLeaguePoints.ts
+++ b/frontend/src/hooks/useAddLeaguePoints.ts
@@ -8,11 +8,16 @@ export type AddLeaguePointsResponse = {
 type UseAddLeaguePointsParams = {
   addLeaguePoints: (userId: number) => Promise<AddLeaguePointsResponse>;
 };
+type PointSystem = { points: number; activity: string }[];
 
 type UseAddLeaguePointsReturn = {
-  addPoints: (userId: number) => Promise<AddLeaguePointsResponse | null>;
+  addPoints: (
+    userId: number,
+    points: number,
+  ) => Promise<AddLeaguePointsResponse | null>;
   error: string | null;
   isLoading: boolean;
+  pointSystem: PointSystem;
 };
 
 export const useAddLeaguePoints = ({
@@ -37,9 +42,16 @@ export const useAddLeaguePoints = ({
     }
   };
 
+  const pointSystem: PointSystem = [
+    { points: 5, activity: "RESOLUCIÓ DE DUBTES (5 pt)" },
+    { points: 10, activity: "CORRECCIÓ DE PR (10 pt)" },
+    { points: 20, activity: "PRESENTACIÓ (20 pt)" },
+  ];
+
   return {
     addPoints,
     error,
     isLoading,
+    pointSystem,
   };
 };


### PR DESCRIPTION
### Created a button for each scoring activity

**Changes:**
As part of this sprint goal, the AddLeaguePoints component has been refactored to include a dedicated button for each scoring activity.

This includes:
- Mapping scoring activities and their associated points via `pointSystem`
- Rendering a button for each activity and ensuring the correct points value is passed on submission
- Partial refactor of the useAddLeaguePoints.ts hook to support the updated structure.

**Preview:**
<img width="587" height="158" alt="Capture d’écran 2026-05-21 à 15 06 17" src="https://github.com/user-attachments/assets/629a83e0-dde1-4932-ae62-7d8ba6a08e5f" />

**Notes**:
- The backend currently applies a default value of 5 points per submission. As a temporary measure, all actions therefore result in 5 points being added on the backend, even though the front is ready to pass the correct points.
- Since CTAs are now less explicit, I added a title to the widget. That's the only UI improvement I added to avoid out of scope.