### PR TITLE
549 update function that resets points weekly

### DIFF
--- a/backend/src/routes/console.php
+++ b/backend/src/routes/console.php
@@ -2,7 +2,15 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('liga:reset-weekly', function () {
+    \App\Models\Liga::query()->update(['points_weekly' => 0]);
+    $this->info('liga:reset-weekly');
+})->purpose('Reset weekly points for all liga entries');
+
+Schedule::command('liga:reset-weekly')->weeklyOn(0, '00:00');

--- a/backend/src/tests/Feature/LigaTests/LigaResetWeeklyCommandTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaResetWeeklyCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Liga;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaResetWeeklyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    public function test_liga_reset_weekly_command_resets_points_weekly_only(): void
+    {
+        $user = User::factory()->create();
+        Liga::create([
+            'user_id' => $user->id,
+            'points' => 100,
+            'points_weekly' => 50,
+        ]);
+    
+        $this->artisan('liga:reset-weekly')->assertExitCode(0);
+    
+        $this->assertEquals(0, Liga::first()->points_weekly);
+        $this->assertEquals(100, Liga::first()->points);
+    }
+}

--- a/frontend/src/components/leagues-ranking/GlobalRanking/GlobalRanking.tsx
+++ b/frontend/src/components/leagues-ranking/GlobalRanking/GlobalRanking.tsx
@@ -1,14 +1,18 @@
 import { useGlobalRanking } from "../../../hooks/useGlobalRanking";
+import { useUser } from "../../../hooks/useUser";
 import { AddLeaguePoints } from "../AddLeaguePoints/AddLeaguePoints";
 import { LeagueList } from "../LeagueList/LeagueList";
 
 export const GlobalRanking = () => {
+  const { user } = useUser();
   const { globalRanking } = useGlobalRanking();
 
   return (
     <section>
       <LeagueList standings={globalRanking} />
-      <AddLeaguePoints users={globalRanking} />
+      {user?.role && user.role !== "student" && (
+        <AddLeaguePoints users={globalRanking} />
+      )}
     </section>
   );
 };

--- a/frontend/src/components/leagues-ranking/__test__/GlobalRanking.test.tsx
+++ b/frontend/src/components/leagues-ranking/__test__/GlobalRanking.test.tsx
@@ -1,7 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchGlobalRanking } from "../../../api/endPointLeagues";
+import { useUserContext } from "../../../context/UserContext";
+import { TypUserRole } from "../../../types";
 import { GlobalRanking } from "../GlobalRanking/GlobalRanking";
 
 vi.mock("../../../api/endPointLeagues", () => ({
@@ -40,6 +42,31 @@ vi.mock("../AddLeaguePoints/AddLeaguePoints", () => ({
   ),
 }));
 
+vi.mock("../../../context/UserContext");
+
+const mockUserContext = (role: TypUserRole) => {
+  vi.mocked(useUserContext).mockReturnValue({
+    user: {
+      id: 1,
+      github_user_name: "test-user",
+      github_id: 123,
+      name: "Test User",
+      email: "test@example.com",
+      password: "",
+      role: role,
+    },
+    isAuthenticated: true,
+    setUser: vi.fn(),
+    signOut: vi.fn(),
+    signIn: vi.fn(),
+    saveUser: vi.fn(),
+    error: null,
+    setError: vi.fn(),
+    loading: false,
+    setIsLoading: vi.fn(),
+  });
+};
+
 const mockRanking = [
   {
     position: 1,
@@ -56,20 +83,23 @@ const mockRanking = [
 ];
 
 describe("GlobalRanking", () => {
+  beforeEach(() => {
+    mockUserContext("student");
+  });
   it("renders the league list after fetch", async () => {
     vi.mocked(fetchGlobalRanking).mockResolvedValue(mockRanking);
-
     render(<GlobalRanking />);
 
     await waitFor(() => {
       expect(screen.getByText("Posició")).toBeInTheDocument();
     });
 
-    expect(screen.getAllByText("Júlia")).toHaveLength(2);
+    expect(screen.getAllByText("Júlia")).toHaveLength(1);
     expect(screen.getByText("94")).toBeInTheDocument();
   });
 
-  it("renders AddLeaguePoints", () => {
+  it("renders AddLeaguePoints for mentors", () => {
+    mockUserContext("mentor");
     vi.mocked(fetchGlobalRanking).mockResolvedValue([]);
 
     render(<GlobalRanking />);
@@ -79,7 +109,8 @@ describe("GlobalRanking", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders AddLeaguePoints with ranking users", async () => {
+  it("renders AddLeaguePoints with ranking users (for mentors)", async () => {
+    mockUserContext("mentor");
     vi.mocked(fetchGlobalRanking).mockResolvedValue(mockRanking);
 
     render(<GlobalRanking />);
@@ -95,17 +126,6 @@ describe("GlobalRanking", () => {
 
   it("renders without crashing on fetch error", () => {
     vi.mocked(fetchGlobalRanking).mockResolvedValue(new Error("fail"));
-
     expect(() => render(<GlobalRanking />)).not.toThrow();
-  });
-
-  it("renders the add point component", () => {
-    vi.mocked(fetchGlobalRanking).mockResolvedValue(mockRanking);
-
-    render(<GlobalRanking />);
-
-    expect(
-      screen.getByRole("form", { name: /add league points/i }),
-    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
It has been implemented a Laravel command called Scheduler which automatically resets the weekly points for all users in the league system.

- Laravel scheduler will run a command every Sunday at midnight (configured in the backend folder routes/console.php). 
- It's easy and accesible to modified if the Mentor would like to start the week either Monday or any other day.
- The command resets the points_weekly field to 0 for every user participating in the leagues. 
- This makes sure each week starts fresh — students begin with zero weekly points and accumulate them as they collaborate. When Sunday arrives, the reset is applied, closing that week's cycle and opening a new one.

Testing:
All 50 tests are passing, including the new one that verifies the reset command works correctly.