### PR TITLE
feat(liga): add weekly reset command for points_weekly

### DIFF
--- a/backend/src/routes/console.php
+++ b/backend/src/routes/console.php
@@ -2,7 +2,15 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('liga:reset-weekly', function () {
+    \App\Models\Liga::query()->update(['points_weekly' => 0]);
+    $this->info('liga:reset-weekly');
+})->purpose('Reset weekly points for all liga entries');
+
+Schedule::command('liga:reset-weekly')->weeklyOn(0, '00:00');

--- a/backend/src/tests/Feature/LigaTests/LigaResetWeeklyCommandTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaResetWeeklyCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Liga;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaResetWeeklyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    public function test_liga_reset_weekly_command_resets_points_weekly_only(): void
+    {
+        $user = User::factory()->create();
+        Liga::create([
+            'user_id' => $user->id,
+            'points' => 100,
+            'points_weekly' => 50,
+        ]);
+    
+        $this->artisan('liga:reset-weekly')->assertExitCode(0);
+    
+        $this->assertEquals(0, Liga::first()->points_weekly);
+        $this->assertEquals(100, Liga::first()->points);
+    }
+}


### PR DESCRIPTION
It has been implemented a Laravel command called Scheduler which automatically resets the weekly points for all users in the league system.

- Laravel scheduler will run a command every Sunday at midnight (configured in the backend folder routes/console.php).
- It's easy and accesible to modified if the Mentor would like to start the week either Monday or any other day.
- The command resets the points_weekly field to 0 for every user participating in the leagues.
- This makes sure each week starts fresh — students begin with zero weekly points and accumulate them as they collaborate. When Sunday arrives, the reset is applied, closing that week's cycle and opening a new one.

Testing: 
All 50 tests are passing, including the new one that verifies the reset command works correctly.
