### PR TITLE
feat: update LigaController to support manual points

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -74,17 +74,22 @@ class LigaController extends Controller
         }
 
         $pointsToAdd = $request->input('points', 5);
+        $isManual    = $request->boolean('manual', false);
 
         $entry->increment('points', $pointsToAdd);
-        $entry->increment('points_weekly', $pointsToAdd);
+
+        if (!$isManual) {
+            $entry->increment('points_weekly', $pointsToAdd);
+        }
 
         $entry->refresh();
 
         return response()->json([
-            'user_id' => $user->id,
-            'points'  => $entry->points,
+            'user_id'       => $user->id,
+            'points'        => $entry->points,
             'points_weekly' => $entry->points_weekly,
         ]);
     }
+
 }
 

--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -73,14 +73,14 @@ class LigaController extends Controller
             ], 403);
         }
 
-        $pointsToAdd = $request->input('points', 5);
-        $isManual    = $request->boolean('manual', false);
+        $validated = $request->validate([
+            'points' => 'nullable|integer|min:1',
+        ]);
 
-        $entry->increment('points', $pointsToAdd);
+         $pointsToAdd = $validated['points'] ?? 5;
 
-        if (!$isManual) {
-            $entry->increment('points_weekly', $pointsToAdd);
-        }
+         $entry->increment('points', $pointsToAdd);
+         $entry->increment('points_weekly', $pointsToAdd);
 
         $entry->refresh();
 

--- a/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
@@ -100,4 +100,23 @@ class LigaAddPointsTest extends TestCase
             ->assertStatus(422);
     }
 
+    public function test_put_increments_by_custom_points_amount(): void
+    {
+        Liga::create([
+            'user_id'       => $this->user->id,
+            'points'        => 0,
+            'points_weekly' => 0,
+        ]);
+
+        $response = $this->putJson("/api/ligas/{$this->user->id}/points", ['points' => 10]);
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'user_id'       => $this->user->id,
+            'points'        => 10,
+            'points_weekly' => 10,
+        ]);
+    }
+
 }

--- a/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
@@ -84,4 +84,24 @@ class LigaAddPointsTest extends TestCase
             'message' => 'User has not opted in to the liga'
         ]);
     }
+
+    public function test_manual_points_does_not_increment_points_weekly(): void
+    {
+        Liga::create([
+            'user_id'       => $this->user->id,
+            'points'        => 0,
+            'points_weekly' => 0,
+        ]);
+
+        $response = $this->putJson("/api/ligas/{$this->user->id}/points", [
+            'points' => 10,
+            'manual' => true,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'points'        => 10,
+            'points_weekly' => 0,
+        ]);
+    }
 }

--- a/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
@@ -85,7 +85,7 @@ class LigaAddPointsTest extends TestCase
         ]);
     }
 
-    public function test_manual_points_does_not_increment_points_weekly(): void
+    public function test_put_returns_422_for_zero_or_negative_points(): void
     {
         Liga::create([
             'user_id'       => $this->user->id,
@@ -93,15 +93,11 @@ class LigaAddPointsTest extends TestCase
             'points_weekly' => 0,
         ]);
 
-        $response = $this->putJson("/api/ligas/{$this->user->id}/points", [
-            'points' => 10,
-            'manual' => true,
-        ]);
+        $this->putJson("/api/ligas/{$this->user->id}/points", ['points' => 0])
+            ->assertStatus(422);
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'points'        => 10,
-            'points_weekly' => 0,
-        ]);
+        $this->putJson("/api/ligas/{$this->user->id}/points", ['points' => -5])
+            ->assertStatus(422);
     }
+
 }


### PR DESCRIPTION
###Description:
Remove manual flag from addPoints endpoint and add input validation.

The manual flag is not needed in this sprint. Points always increment
both fields (points and points_weekly) as required by the weekly league
classification logic.

Added validation to reject zero or negative point values (min:1).

