### PR TITLE
feat(#645): add end_date autocalculation from start_date and duration

### DIFF
--- a/frontend/src/components/code-connect/FormCreate.tsx
+++ b/frontend/src/components/code-connect/FormCreate.tsx
@@ -6,6 +6,7 @@ import { createCodeConnect } from "../../api/endPointCodeConnect";
 import { formatDocumentIcons } from "../../icons/formatDocumentIconsArray";
 import { IntCodeConnect, Task } from "../../types";
 import { RoadmapField } from "../forms/RoadmapField";
+import { computeEndDate } from "./utils/computeEndDate";
 import {
   contentTechsBackCodeConnect,
   contentTechsFrontCodeConnect,
@@ -32,6 +33,7 @@ const FormCreate = () => {
     unitTime: "",
     limit_date_inscription: "",
     start_date: "",
+    end_date: "",
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [roadmap, setRoadmap] = useState<Task[]>([]);
@@ -41,6 +43,9 @@ const FormCreate = () => {
     setFormData((prev) => ({
       ...prev,
       [field]: value,
+      ...(field === "unitTime" && {
+        end_date: computeEndDate(prev.start_date ?? "", prev.time, value),
+      }),
     }));
   };
 
@@ -52,12 +57,24 @@ const FormCreate = () => {
     rawValue: string,
   ) => {
     if (rawValue === "") {
-      return setFormData((prev) => ({ ...prev, [field]: 0 }));
+      return setFormData((prev) => ({
+        ...prev,
+        [field]: 0,
+        ...(field === "time" && {
+          end_date: computeEndDate(prev.start_date ?? "", 0, prev.unitTime),
+        }),
+      }));
     }
 
     const value = Number(rawValue);
     if (!isNaN(value) && value >= 0) {
-      setFormData((prev) => ({ ...prev, [field]: value }));
+      setFormData((prev) => ({
+        ...prev,
+        [field]: value,
+        ...(field === "time" && {
+          end_date: computeEndDate(prev.start_date ?? "", value, prev.unitTime),
+        }),
+      }));
     }
   };
 
@@ -65,7 +82,13 @@ const FormCreate = () => {
     field: keyof Pick<IntCodeConnect, "limit_date_inscription" | "start_date">,
     value: string,
   ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+      ...(field === "start_date" && {
+        end_date: computeEndDate(value, prev.time, prev.unitTime),
+      }),
+    }));
   };
 
   const validateForm = (): boolean => {
@@ -102,6 +125,7 @@ const FormCreate = () => {
       );
       return false;
     }
+
     if (
       !title.trim() ||
       !description.trim() ||
@@ -150,6 +174,7 @@ const FormCreate = () => {
       time_duration: getTimeDuration(formData.time, formData.unitTime),
       limit_date_inscription: formData.limit_date_inscription,
       start_date: formData.start_date,
+      ...(formData.end_date && { end_date: formData.end_date }),
     };
 
     try {
@@ -227,7 +252,6 @@ const FormCreate = () => {
           {contentTechsFrontCodeConnect.map((item) => {
             const IconComponent = item.icon;
             const isSelected = formData.language_frontend.includes(item.label);
-
             return (
               <label
                 key={item.label}
@@ -261,7 +285,6 @@ const FormCreate = () => {
           {contentTechsBackCodeConnect.map((item) => {
             const IconComponent = item.icon;
             const isSelected = formData.language_backend.includes(item.label);
-
             return (
               <label
                 key={item.label}
@@ -317,9 +340,11 @@ const FormCreate = () => {
           </div>
         </div>
       </div>
+
       <div className="mx-[-3.7rem] border-t border-gray-300 my-8"></div>
       <RoadmapField setRoadmap={setRoadmap} />
       <div className="mx-[-3.7rem] border-t border-gray-300 my-8"></div>
+
       <div className="lg:w-2/3 my-4">
         <div className="grid gap-4 lg:grid-cols-3 items-center">
           <label htmlFor="limit_date_inscription" className="block font-medium">
@@ -354,6 +379,23 @@ const FormCreate = () => {
             disabled={isSubmitting}
             onChange={(e) => handleDeadLine("start_date", e.target.value)}
             min={getMinDeadline()}
+          />
+        </div>
+      </div>
+
+      <div className="lg:w-2/3 my-4">
+        <div className="grid gap-4 lg:grid-cols-3 items-center">
+          <label htmlFor="end_date" className="block font-medium text-gray-500">
+            Data de finalització del projecte
+          </label>
+          <input
+            id="end_date"
+            className="border border-gray-300 rounded-lg py-2 px-4 bg-gray-100 text-gray-500 cursor-not-allowed"
+            type="date"
+            value={formData.end_date || ""}
+            readOnly
+            disabled
+            tabIndex={-1}
           />
         </div>
       </div>

--- a/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
+++ b/frontend/src/components/code-connect/__test__/FormCreate.test.tsx
@@ -464,4 +464,28 @@ describe("FormCreateCodeConnect", () => {
       expect(devsBackInput.placeholder).toBe("0");
     });
   });
+  it("should calculate end_date automatically when start_date, time and unitTime are set", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<FormCreateCodeConnect />);
+
+    const startDateInput = screen.getByLabelText(
+      /data d'inici del projecte/i,
+    ) as HTMLInputElement;
+    await user.type(startDateInput, "2026-01-01");
+
+    const timeInput = screen.getByLabelText(
+      /durada del projecte/i,
+    ) as HTMLInputElement;
+    await user.type(timeInput, "2");
+
+    const unitTimeSelect = screen.getByLabelText(/tipus durada/i);
+    await user.selectOptions(unitTimeSelect, "month");
+
+    const endDateInput = document.getElementById(
+      "end_date",
+    ) as HTMLInputElement;
+    await waitFor(() => {
+      expect(endDateInput.value).toBe("2026-03-01");
+    });
+  });
 });

--- a/frontend/src/components/code-connect/utils/computeEndDate.ts
+++ b/frontend/src/components/code-connect/utils/computeEndDate.ts
@@ -1,0 +1,15 @@
+export const computeEndDate = (
+  startDate: string,
+  time: number,
+  unitTime: string,
+): string => {
+  if (!startDate || !time || !unitTime) return "";
+  const [year, month, day] = startDate.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  if (unitTime === "week") date.setDate(date.getDate() + time * 7);
+  if (unitTime === "month") date.setMonth(date.getMonth() + time);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -61,6 +61,7 @@ export interface IntCodeConnect {
   time_duration: string;
   limit_date_inscription: string;
   start_date: string;
+  end_date?: string;
 }
 
 export type TypTechnologyResource =


### PR DESCRIPTION
Adds end_date autocalculation to the project creation form.

- Add computeEndDate utility function
- Add end_date to form state (readonly field)
- end_date recalculates automatically when start_date, time or unitTime changes
- Include end_date in API request payload when computed
- Add end_date optional field to IntCodeConnect type
- Test: verifies end_date calculates correctly from start_date + duration

Closes #645