### PR TITLE
League color fix

### DIFF
--- a/frontend/src/components/leagues-ranking/LeagueList/LeagueList.tsx
+++ b/frontend/src/components/leagues-ranking/LeagueList/LeagueList.tsx
@@ -1,14 +1,18 @@
 import type { LeagueListProps } from "../../../types/league";
 
-export const LeagueList = ({ standings }: LeagueListProps) => {
+export const LeagueList = ({
+  standings,
+  showUp,
+  showDown,
+}: LeagueListProps) => {
   const getStyle = (index: number) => {
     const base =
       "grid grid-cols-6 border-b last:border-b-0 border-gray-400 px-4 py-4 text-sm text-center text-slate-950";
 
     const color =
-      standings.length > 3 && index < 3
+      showUp && standings.length > 3 && index < 3
         ? "bg-green-100"
-        : standings.length > 6 && index >= standings.length - 3
+        : showDown && standings.length > 6 && index >= standings.length - 3
           ? "bg-red-100"
           : "";
 

--- a/frontend/src/components/leagues-ranking/WeeklyRanking/WeeklyRanking.tsx
+++ b/frontend/src/components/leagues-ranking/WeeklyRanking/WeeklyRanking.tsx
@@ -11,10 +11,14 @@ export const WeeklyRanking = () => {
 
   return (
     <section>
-      {leagueGroups.map(([id, league]) => (
+      {leagueGroups.map(([id, league], index) => (
         <div key={id} className="my-10">
           <h1>Lliga {LEAGUE_LABELS[id] ?? id}</h1>
-          <LeagueList standings={league} />
+          <LeagueList
+            standings={league}
+            showUp={index > 0}
+            showDown={index + 1 < leagueGroups.length}
+          />
         </div>
       ))}
     </section>

--- a/frontend/src/components/leagues-ranking/__test__/LeagueList.test.tsx
+++ b/frontend/src/components/leagues-ranking/__test__/LeagueList.test.tsx
@@ -44,8 +44,8 @@ describe("LeagueList", () => {
     expect(screen.queryByTestId("league-position-1")).not.toBeInTheDocument();
   });
 
-  it("applies green background to the top 3 when there are more than 3 participants", () => {
-    render(<LeagueList standings={createMockStandings(4)} />);
+  it("applies green background to the (ascending) top 3 when there are more than 3 participants", () => {
+    render(<LeagueList standings={createMockStandings(4)} showUp />);
     expect(screen.getByTestId("league-position-1")).toHaveClass("bg-green-100");
     expect(screen.getByTestId("league-position-2")).toHaveClass("bg-green-100");
     expect(screen.getByTestId("league-position-3")).toHaveClass("bg-green-100");
@@ -54,8 +54,8 @@ describe("LeagueList", () => {
     );
   });
 
-  it("applies red background to the last 3 when there are more than 6 participants", () => {
-    render(<LeagueList standings={createMockStandings(7)} />);
+  it("applies red background to the (descending) last 3 when there are more than 6 participants", () => {
+    render(<LeagueList standings={createMockStandings(7)} showDown />);
     expect(screen.getByTestId("league-position-5")).toHaveClass("bg-red-100");
     expect(screen.getByTestId("league-position-6")).toHaveClass("bg-red-100");
     expect(screen.getByTestId("league-position-7")).toHaveClass("bg-red-100");

--- a/frontend/src/types/league.ts
+++ b/frontend/src/types/league.ts
@@ -2,14 +2,19 @@ export type Liga = {
   position: number;
   user_id: number;
   username: string;
+  points?: number;
   points_weekly: number;
+  status?: string;
+  language?: string;
   league_id: number;
 };
 
 export type LigaResponse = { [key: string]: Liga[] };
 
 export type LeagueListProps = {
-  standings: Omit<Ranking, "points_weekly" | "league_id">[];
+  standings: Omit<Ranking, "points_weekly" | "league_id">[] | Liga[];
+  showUp?: boolean;
+  showDown?: boolean;
 };
 
 export type Ranking = {


### PR DESCRIPTION
**Context**
Previously, the top 3 and last 3 participants were marked in green and red in both the global ranking and league tables, separately for each table.
During the last sprint planning, it was clarified that colors should indicate participants who can ascend or descend within leagues, not simply the top/bottom positions of each table.

**Changes**
- Updated the list component to accept optional showUp and showDown props.
- Disabled color highlighting in the global ranking.
- Enabled color highlighting in the weekly ranking (leagues) only when relevant: for example, the top 3 of the gold league cannot ascend, and the last 3 of the last league cannot descend, so no colors are shown in those cases.