### PR TITLE
feat: add league promotion and demotion processing

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,6 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../src/routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        \App\Console\Commands\ProcessLeaguePromotions::class,
+    ])
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->api(prepend: [
             \Illuminate\Http\Middleware\HandleCors::class,

--- a/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
+++ b/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+namespace App\Console\Commands;
+use App\Enums\LeagueTypeEnum;
+use App\Models\Liga;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class ProcessLeaguePromotions extends Command
+{
+    protected $signature = 'liga:process-promotions';
+    protected $description = 'Process weekly league promotions and demotions based on points_weekly';
+
+    public function handle(): void {
+        DB::transaction(function () {
+            $this->processPromotionsAndDemotions();
+        });
+        $this->info('League promotions and demotions processed successfully.');
+    }
+
+    private function processPromotionsAndDemotions(): void {
+        $maxLeague = Liga::max('league_id');
+        $updates = [];
+        for ($leagueId = 1; $leagueId <= $maxLeague; $leagueId++) {
+            $entries = Liga::where('league_id', $leagueId)->orderByDesc('points_weekly')->get();
+            $total = $entries->count();
+            if ($total < 3) {
+                continue;
+            }
+            $topCount = (int) ceil($total * 0.33);
+            $bottomCount = (int) ceil($total * 0.33);
+            if ($leagueId < LeagueTypeEnum::Gold->value) {
+                $entries->take($topCount)->each(function ($entry) use ($leagueId, &$updates): void {
+                    $updates[$entry->id] = $leagueId + 1;
+                });
+            }
+
+            if ($leagueId > LeagueTypeEnum::Bronze->value) {
+                $entries->slice($total - $bottomCount)->each(function ($entry) use ($leagueId, &$updates): void {
+                    $updates[$entry->id] = $leagueId - 1;
+                });
+            }
+        }
+
+        foreach ($updates as $entryId => $newLeagueId) {
+            Liga::where('id', $entryId)->update(['league_id' => $newLeagueId, ]);
+        }
+    }
+}

--- a/backend/src/app/Enums/LeagueTypeEnum.php
+++ b/backend/src/app/Enums/LeagueTypeEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum LeagueTypeEnum:int
+{
+    case Bronze = 1;
+    case Silver = 2;
+    case Gold = 3;
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\LigaStatusEnum;
+use App\Enums\LeagueTypeEnum;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,7 +31,7 @@ class Liga extends Model
     protected $casts = [
         'points'=> 'integer',
         'points_weekly'=> 'integer',
-        'league_id'=> 'integer',
+        'league_id'=> LeagueTypeEnum::class,
         'status'=> LigaStatusEnum::class, 
     ];
 

--- a/backend/src/database/factories/LigaFactory.php
+++ b/backend/src/database/factories/LigaFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Enums\LanguageEnum;
+use App\Enums\LeagueTypeEnum;
 use App\Enums\LigaStatusEnum;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -22,7 +23,7 @@ class LigaFactory extends Factory
             'points_weekly' => fake()->numberBetween(0, 100),
             'language'      => fake()->randomElement(LanguageEnum::values()),
             'status'        => fake()->randomElement(LigaStatusEnum::values()),
-            'league_id'     => fake()->numberBetween(1, 4),
+                'league_id'     => fake()->randomElement(LeagueTypeEnum::values()),
         ];
     }
 }

--- a/backend/src/database/seeders/LigaSeeder.php
+++ b/backend/src/database/seeders/LigaSeeder.php
@@ -6,6 +6,7 @@ namespace Database\Seeders;
 
 use App\Enums\LanguageEnum;
 use App\Enums\LigaStatusEnum;
+use App\Enums\LeagueTypeEnum;
 use App\Models\Liga;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -22,7 +23,7 @@ class LigaSeeder extends Seeder
                     'points_weekly' => fake()->numberBetween(0, 100),
                     'language'      => fake()->randomElement(LanguageEnum::values()),
                     'status'        => fake()->randomElement(LigaStatusEnum::values()),
-                    'league_id'     => fake()->numberBetween(1, 4),
+                    'league_id'     => fake()->randomElement(LeagueTypeEnum::values()),
                 ]);
             }
         });

--- a/backend/src/tests/Feature/LigaTests/LigaFactorySeederTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaFactorySeederTest.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 namespace Tests\Feature\LigaTests;
-
 use App\Models\Liga;
+use \App\Enums\LeagueTypeEnum;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -94,7 +94,6 @@ class LigaFactorySeederTest extends TestCase
     public function test_liga_factory_league_id_is_an_integer(): void
     {
         $liga = Liga::factory()->create();
-
-        $this->assertIsInt($liga->league_id);
-    }
+        $this->assertInstanceOf(LeagueTypeEnum::class, $liga->league_id);    
+        }
 }

--- a/backend/src/tests/Feature/LigaTests/LigaPromotionTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaPromotionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+namespace Tests\Feature\Liga;
+use App\Enums\LeagueTypeEnum;
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaPromotionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_top_user_gets_promoted(): void {
+        $users = User::factory()->count(3)->create();
+        Liga::create(['user_id' => $users[0]->id,'points_weekly' => 100,'league_id' => LeagueTypeEnum::Bronze->value]);
+        Liga::create(['user_id' => $users[1]->id,'points_weekly' => 50,'league_id' => LeagueTypeEnum::Bronze->value]);
+        Liga::create(['user_id' => $users[2]->id,'points_weekly' => 10,'league_id' => LeagueTypeEnum::Bronze->value]);
+        $this->artisan('liga:process-promotions')->assertSuccessful();
+        $this->assertEquals( LeagueTypeEnum::Silver, Liga::where('user_id', $users[0]->id)->first()->league_id);
+    }
+
+    public function test_bottom_user_gets_demoted(): void {
+        $users = User::factory()->count(3)->create();
+        Liga::create(['user_id' => $users[0]->id,'points_weekly' => 100,'league_id' => LeagueTypeEnum::Silver->value]);
+        Liga::create(['user_id' => $users[1]->id,'points_weekly' => 50,'league_id' => LeagueTypeEnum::Silver->value]);
+        Liga::create(['user_id' => $users[2]->id,'points_weekly' => 10,'league_id' => LeagueTypeEnum::Silver->value]);
+        $this->artisan('liga:process-promotions')->assertSuccessful();
+        $this->assertEquals(LeagueTypeEnum::Bronze, Liga::where('user_id', $users[2]->id)->first()->league_id);
+    }
+
+    public function test_user_in_gold_cannot_be_promoted(): void {
+        $users = User::factory()->count(3)->create();
+        Liga::create(['user_id' => $users[0]->id,'points_weekly' => 100,'league_id' => LeagueTypeEnum::Gold->value]);
+        Liga::create(['user_id' => $users[1]->id,'points_weekly' => 50,'league_id' => LeagueTypeEnum::Gold->value]);
+        Liga::create(['user_id' => $users[2]->id,'points_weekly' => 10,'league_id' => LeagueTypeEnum::Gold->value]);
+        $this->artisan('liga:process-promotions')->assertSuccessful();
+        $this->assertEquals(LeagueTypeEnum::Gold, Liga::where('user_id', $users[0]->id)->first()->league_id);
+    }
+
+    public function test_league_with_less_than_3_users_is_skipped(): void {
+        $users = User::factory()->count(2)->create();
+        Liga::create(['user_id' => $users[0]->id,'points_weekly' => 100,'league_id' => LeagueTypeEnum::Bronze->value]);
+        Liga::create(['user_id' => $users[1]->id,'points_weekly' => 50,'league_id' => LeagueTypeEnum::Bronze->value]);
+        $this->artisan('liga:process-promotions')->assertSuccessful();
+        $this->assertEquals( LeagueTypeEnum::Bronze, Liga::where('user_id', $users[0]->id)->first()->league_id);
+        $this->assertEquals( LeagueTypeEnum::Bronze, Liga::where('user_id', $users[1]->id)->first()->league_id);
+    }
+}

--- a/backend/src/tests/Feature/LigaTests/LigaTableTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaTableTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Liga;
 
 use App\Models\Liga;
 use App\Models\User;
+use \App\Enums\LeagueTypeEnum;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
@@ -50,8 +51,7 @@ class LigaTableTest extends TestCase
     
         $this->assertEquals(5, $liga->points_weekly);
         $this->assertEquals('PHP', $liga->language);
-        $this->assertEquals(1, $liga->league_id);
-    
+        $this->assertEquals(LeagueTypeEnum::Bronze, $liga->league_id);    
         $statusValue = $liga->status instanceof \BackedEnum
             ? $liga->status->value
             : $liga->status;


### PR DESCRIPTION
**Description**

Implemented the weekly league promotion and demotion system 

**Changes included**

- Added `ProcessLeaguePromotions` artisan command
- Implemented promotion/demotion logic between leagues
- Added protection for minimum and maximum league boundaries
- Prevented users from being promoted/demoted multiple times in the same execution
- Added `LeagueTypeEnum` to define league 
- Updated `Liga` model to use league enum casting
- Updated factories and seeders to use valid league values only
- Added feature tests covering