### PR TITLE
Feature/593 ticketing: add DropdownMenu

### DIFF
--- a/frontend/src/components/atoms/DropdownButtonComponent.tsx
+++ b/frontend/src/components/atoms/DropdownButtonComponent.tsx
@@ -5,6 +5,7 @@ interface DropdownButtonComponentProps {
   onClick?: () => void;
   icon?: string;
   disabled?: boolean;
+  className?: string;
 }
 
 const DropdownButtonComponent: FC<DropdownButtonComponentProps> = ({
@@ -12,12 +13,13 @@ const DropdownButtonComponent: FC<DropdownButtonComponentProps> = ({
   onClick,
   icon,
   disabled = false,
+  className,
 }) => {
   return (
     <button
       title={title || "Usuari"}
       onClick={onClick}
-      className={`flex items-center justify-start gap-3 px-3 py-1 mx-3 text-[0.85rem] whitespace-nowrap transition rounded-md ${disabled ? "cursor-default" : "cursor-pointer hover:bg-[#fcecec]"}`}
+      className={`flex items-center justify-start gap-3 px-3 py-1 text-[0.85rem] whitespace-nowrap transition rounded-md ${className ?? "mx-3"} ${disabled ? "cursor-default" : "cursor-pointer hover:bg-[#fcecec]"}`}
       disabled={disabled}
     >
       <span>

--- a/frontend/src/components/atoms/DropdownMenu.test.tsx
+++ b/frontend/src/components/atoms/DropdownMenu.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import DropdownMenu from "./DropdownMenu";
+import { vi } from "vitest";
+
+const options = [
+  { label: "Nou", value: "pending" },
+  { label: "En progrés", value: "in_progress" },
+  { label: "Tancat", value: "closed" },
+];
+
+describe("DropdownMenu", () => {
+  it("should render the current value", () => {
+    render(
+      <DropdownMenu currentValue="Nou" options={options} onSelect={vi.fn()} />,
+    );
+    const button = screen.getByRole("button", { name: "Nou" });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("should open the dropdown when clicked", () => {
+    render(
+      <DropdownMenu currentValue="Nou" options={options} onSelect={vi.fn()} />,
+    );
+    const button = screen.getByRole("button", { name: "Nou" });
+    fireEvent.click(button);
+
+    expect(
+      screen.getByRole("button", { name: "En progrés" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tancat" })).toBeInTheDocument();
+  });
+
+  it("should call onSelect with the correct value when an option is clicked", () => {
+    const handleSelect = vi.fn();
+    render(
+      <DropdownMenu
+        currentValue="Nou"
+        options={options}
+        onSelect={handleSelect}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Nou" }));
+    fireEvent.click(screen.getByRole("button", { name: "Tancat" }));
+
+    expect(handleSelect).toHaveBeenCalledWith("closed");
+  });
+
+  it("should close the dropdown after selecting an option", () => {
+    render(
+      <DropdownMenu currentValue="Nou" options={options} onSelect={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Nou" }));
+    fireEvent.click(screen.getByRole("button", { name: "Tancat" }));
+
+    expect(
+      screen.queryByRole("button", { name: "En progrés" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should disable the trigger button when disabled prop is true", () => {
+    render(
+      <DropdownMenu
+        currentValue="Nou"
+        options={options}
+        onSelect={vi.fn()}
+        disabled={true}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Nou" });
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/components/atoms/DropdownMenu.tsx
+++ b/frontend/src/components/atoms/DropdownMenu.tsx
@@ -1,0 +1,61 @@
+import { useRef, useEffect, useState } from "react";
+import DropdownButtonComponent from "./DropdownButtonComponent";
+
+interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+interface DropdownMenuProps {
+  currentValue: string;
+  options: DropdownOption[];
+  onSelect: (value: string) => void;
+  disabled?: boolean;
+}
+
+const DropdownMenu = ({
+  currentValue,
+  options,
+  onSelect,
+  disabled = false,
+}: DropdownMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <DropdownButtonComponent
+        title={currentValue}
+        onClick={() => setIsOpen((prev) => !prev)}
+        disabled={disabled}
+        className="mx-0"
+      />
+      {isOpen && (
+        <div className="absolute z-50 mt-1 w-36 rounded-md border border-border bg-white shadow-lg">
+          {options.map((option) => (
+            <DropdownButtonComponent
+              key={option.value}
+              title={option.label}
+              onClick={() => {
+                onSelect(option.value);
+                setIsOpen(false);
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DropdownMenu;


### PR DESCRIPTION
This PR adds a generic DropdownMenu atom component that wraps DropdownButtonComponent with open/close state and click outside detection. DropdownButtonComponent has been extended with an optional className prop to allow margin overrides when used inside table cells.
