### PR TITLE
636 restrict addpoints endpoint to mentor role only

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -11,6 +11,11 @@ use Illuminate\Http\Request;
 
 class LigaController extends Controller
 {
+    public function __construct()
+    {
+    $this->middleware('check.permission:add liga points')->only(['addPoints']);
+    }
+
 
     public function index()
     {

--- a/backend/src/database/seeders/PermissionSeeder.php
+++ b/backend/src/database/seeders/PermissionSeeder.php
@@ -49,6 +49,9 @@ class PermissionSeeder extends Seeder
         Permission::firstOrCreate(['name' => 'assign tickets', 'guard_name' => 'api']);
         Permission::firstOrCreate(['name' => 'add closing comment', 'guard_name' => 'api']);
 
+        // Permisos - Liga
+        Permission::firstOrCreate(['name' => 'add liga points', 'guard_name' => 'api']);
+       
         $this->command->info('✅ Permissions created successfully!');
         $this->command->info('Total permissions: ' . Permission::count());
     }

--- a/backend/src/database/seeders/RolePermissionSeeder.php
+++ b/backend/src/database/seeders/RolePermissionSeeder.php
@@ -72,6 +72,7 @@ class RolePermissionSeeder extends Seeder
                 'update ticket status',
                 'update ticket priority',
                 'assign tickets',
+                'add liga points',
             ],
 
             'admin' => [
@@ -97,6 +98,7 @@ class RolePermissionSeeder extends Seeder
                 'update ticket priority',
                 'assign tickets',
                 'add closing comment',
+                'add liga points',
             ],
 
             'superadmin' => 'all',  // Special marker for all permissions

--- a/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaAddPointsTest.php
@@ -19,9 +19,8 @@ class LigaAddPointsTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = User::factory()->create();
-
-        $this->actingAs($this->user, 'sanctum');
+        $this->user = $this->authenticateUserWithRole('mentor');
+        
     }
 
     public function test_put_increments_points_by_5(): void

--- a/backend/src/tests/Feature/LigaTests/LigaEndpointAuthTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaEndpointAuthTest.php
@@ -47,11 +47,31 @@ class LigaEndpointAuthTest extends TestCase
 
     public function test_authenticated_user_can_add_points(): void
     {
-        $user = User::factory()->create();
+        $user = $this->authenticateUserWithRole('mentor');
         Liga::factory()->create(['user_id' => $user->id]);
 
-        $response = $this->actingAs($user)->putJson("/api/ligas/{$user->id}/points", ['points' => 10]);
-
-        $response->assertStatus(200);
+        $this->putJson("/api/ligas/{$user->id}/points", ['points' => 10])
+            ->assertStatus(200);
     }
+
+    public function test_student_cannot_add_points(): void
+    {
+        $student = $this->authenticateUserWithRole('student');
+        Liga::factory()->create(['user_id' => $student->id]);
+
+        $this->putJson("/api/ligas/{$student->id}/points")
+            ->assertStatus(403);
+    }
+
+    public function test_mentor_can_add_points(): void
+    {
+        $mentor = $this->authenticateUserWithRole('mentor');
+        Liga::factory()->create(['user_id' => $mentor->id]);
+
+        $this->putJson("/api/ligas/{$mentor->id}/points")
+            ->assertStatus(200);
+    }
+
+
+
 }

--- a/backend/src/tests/Feature/LigaTests/LigaStubTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaStubTest.php
@@ -31,7 +31,7 @@ class LigaStubTest extends TestCase
 
     public function test_add_points_updates_user_points(): void
     {
-        $user = User::factory()->create();
+       $user = $this->createUserWithRole('mentor');
 
         // addPoints uses firstOrFail(), so a liga entry must exist before calling the endpoint
         Liga::create([


### PR DESCRIPTION
## Summary

Restricts the `addPoints` endpoint to users with the `mentor` or `admin` role.
Previously, any authenticated user could add liga points to a student.

## Changes

- PermissionSeeder: new `add liga points` permission
- RolePermissionSeeder: permission assigned to `mentor` and `admin` roles
- LigaController: constructor middleware `check.permission:add liga points` applied only to `addPoints`
- LigaAddPointsTest: setUp user updated to mentor role so existing tests remain valid under the new restriction
- LigaEndpointAuthTest: fixed existing auth test + added two new role-based tests:
 - student → 403 Forbidden
  - mentor → 200 OK
