### PR TITLE
fix(#594): fix double /api/ prefix in getComments and addComment URLs

### DIFF
--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -46,7 +46,7 @@ export const getComments = async (
   ticketId: number,
 ): Promise<TicketComment[]> => {
   const token = localStorage.getItem("auth_token");
-  const url = `${API_URL}/api/tickets/${ticketId}/comments`;
+  const url = `${API_URL}tickets/${ticketId}/comments`;
 
   const response = await axios.get<{ data: TicketComment[] }>(url, {
     headers: {
@@ -62,7 +62,7 @@ export const addComment = async (
   comment: string,
 ): Promise<TicketComment> => {
   const token = localStorage.getItem("auth_token");
-  const url = `${API_URL}/api/tickets/${ticketId}/comments`;
+  const url = `${API_URL}tickets/${ticketId}/comments`;
 
   const response = await axios.post<{ data: TicketComment }>(
     url,


### PR DESCRIPTION
getComments and addComment functions were building URLs with a double /api/ 
prefix because API_URL already includes /api/ and the URL template also 
added /api/ explicitly.

Changes:
endPointTickets.ts: changed `${API_URL}/api/tickets/${ticketId}/comments` 
to `${API_URL}tickets/${ticketId}/comments`
