### PR TITLE
feat: create liga_point_histories migration

### DIFF
--- a/backend/src/database/migrations/2026_06_03_132730_create_liga_point_histories_table.php
+++ b/backend/src/database/migrations/2026_06_03_132730_create_liga_point_histories_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('liga_point_histories', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('points');
+            $table->string('activity');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('liga_point_histories');
+    }
+};


### PR DESCRIPTION
### **Summary**

- Creates `liga_point_histories` table to store the points history for each student
- Fields: `user_id` (FK → users), `points` (unsignedInteger), `activity` (string), `timestamps`

### **Test plan**

- Run `php artisan migrate `- no errors