### PR TITLE
Feature/725 Ticketing - add updateComment API function with happy path test

### DIFF
--- a/frontend/src/api/__tests__/endPointTickets.test.ts
+++ b/frontend/src/api/__tests__/endPointTickets.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import axios from "axios";
-import { createTicket, addComment, getComments } from "../endPointTickets";
+import { createTicket, addComment, getComments, updateComment } from "../endPointTickets";
 import { IntCreateTicket } from "../../types/ticketingTypes";
 
 vi.mock("axios");
@@ -84,5 +84,29 @@ describe("addComment", () => {
 
     expect(result).toEqual(mockComment);
     expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("updateComment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should update a comment and return the updated data", async () => {
+    const mockUpdatedComment = { id: 42, comment: "edited text", user: { id: 1 } };
+    vi.mocked(axios.put).mockResolvedValue({ data: { data: mockUpdatedComment } });
+
+    const result = await updateComment(1, 42, "edited text");
+
+    expect(result).toEqual(mockUpdatedComment);
+    expect(axios.put).toHaveBeenCalledWith(
+      expect.stringContaining("tickets/1/comments/42"),
+      { comment: "edited text" },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
   });
 });

--- a/frontend/src/api/__tests__/endPointTickets.test.ts
+++ b/frontend/src/api/__tests__/endPointTickets.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import axios from "axios";
-import { createTicket, addComment, getComments, updateComment } from "../endPointTickets";
+import {
+  createTicket,
+  addComment,
+  getComments,
+  updateComment,
+} from "../endPointTickets";
 import { IntCreateTicket } from "../../types/ticketingTypes";
 
 vi.mock("axios");
@@ -93,8 +98,14 @@ describe("updateComment", () => {
   });
 
   it("should update a comment and return the updated data", async () => {
-    const mockUpdatedComment = { id: 42, comment: "edited text", user: { id: 1 } };
-    vi.mocked(axios.put).mockResolvedValue({ data: { data: mockUpdatedComment } });
+    const mockUpdatedComment = {
+      id: 42,
+      comment: "edited text",
+      user: { id: 1 },
+    };
+    vi.mocked(axios.put).mockResolvedValue({
+      data: { data: mockUpdatedComment },
+    });
 
     const result = await updateComment(1, 42, "edited text");
 

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -77,3 +77,21 @@ export const addComment = async (
 
   return response.data.data;
 };
+
+export const updateComment = async (
+  ticketId: number,
+  commentId: number,
+  comment: string,
+): Promise<TicketComment> => {
+  const token = localStorage.getItem("auth_token");
+  const url = `${API_URL}tickets/${ticketId}/comments/${commentId}`;
+
+  const response = await axios.put<{ data: TicketComment }>(url, { comment }, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return response.data.data;
+};

--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -86,12 +86,16 @@ export const updateComment = async (
   const token = localStorage.getItem("auth_token");
   const url = `${API_URL}tickets/${ticketId}/comments/${commentId}`;
 
-  const response = await axios.put<{ data: TicketComment }>(url, { comment }, {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+  const response = await axios.put<{ data: TicketComment }>(
+    url,
+    { comment },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
     },
-  });
+  );
 
   return response.data.data;
 };


### PR DESCRIPTION
**Summary** 

- Adds the updateComment function to the ticketing API endpoint helper. 
This function makes a PUT request to /tickets/{ticketId}/comments/{commentId} with the updated comment text, passing the bearer authorization token.

- Includes unit tests to verify that the request payload and headers are correctly configured.

Note for Reviewers / How to Test:
This PR only introduces the API layer function and its tests (subtask 1 of 4). It is not yet connected to any page UI. Please verify this PR exclusively by running the unit tests. thank you!

Note about lenght, my original PR was smaller than 50 lines, but due to frontend automated tests had to run prettier, and it exceeded then.