### PR TITLE
Feature/725 ticketing make comment form editable

### DIFF
--- a/frontend/src/components/ticketing/TicketCommentForm.tsx
+++ b/frontend/src/components/ticketing/TicketCommentForm.tsx
@@ -24,16 +24,23 @@ const TicketCommentForm = ({
 
   const isOwner = authorId === currentUserId;
 
+  const handleEditComment = async () => {
+    if (!editText.trim()) return;
+    await onSubmit(editText);
+  };
+
+  const handleNewComment = async () => {
+    if (!comment.trim()) return;
+    await onSubmit(comment);
+    setComment("");
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
     if (initialValue !== undefined) {
-      if (!editText.trim()) return;
-      await onSubmit(editText);
+      await handleEditComment();
     } else {
-      if (!comment.trim()) return;
-      await onSubmit(comment);
-      setComment("");
+      await handleNewComment();
     }
   };
 

--- a/frontend/src/components/ticketing/TicketCommentForm.tsx
+++ b/frontend/src/components/ticketing/TicketCommentForm.tsx
@@ -26,10 +26,15 @@ const TicketCommentForm = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const text = initialValue ? editText : comment;
-    if (!text.trim()) return;
-    await onSubmit(text);
-    if (!initialValue) setComment("");
+
+    if (initialValue !== undefined) {
+      if (!editText.trim()) return;
+      await onSubmit(editText);
+    } else {
+      if (!comment.trim()) return;
+      await onSubmit(comment);
+      setComment("");
+    }
   };
 
   const textareaClass =

--- a/frontend/src/components/ticketing/TicketCommentForm.tsx
+++ b/frontend/src/components/ticketing/TicketCommentForm.tsx
@@ -7,6 +7,7 @@ type Props = {
   initialValue?: string;
   authorId?: number;
   date?: string;
+  currentUserId?: number;
 };
 
 const TicketCommentForm = ({
@@ -16,9 +17,12 @@ const TicketCommentForm = ({
   initialValue,
   authorId,
   date,
+  currentUserId,
 }: Props) => {
   const [comment, setComment] = useState("");
   const [editText, setEditText] = useState(initialValue ?? "");
+
+  const isOwner = authorId === currentUserId;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,9 +41,10 @@ const TicketCommentForm = ({
       {initialValue ? (
         <>
           <textarea
-            className={textareaClass}
-            value={editText}
-            onChange={(e) => setEditText(e.target.value)}
+            className={`${textareaClass} ${!isOwner ? "bg-gray-50" : ""}`}
+            value={isOwner ? editText : initialValue}
+            onChange={isOwner ? (e) => setEditText(e.target.value) : undefined}
+            readOnly={!isOwner}
           />
           {(authorId || date) && (
             <p className="mt-1 text-xs text-gray-500">
@@ -56,12 +61,14 @@ const TicketCommentForm = ({
         />
       )}
       <div className="mt-4 flex gap-2">
-        <button
-          className="bg-[#B91879] px-10 py-4 text-sm font-bold text-white hover:shadow-md"
-          type="submit"
-        >
-          Desar
-        </button>
+        {(!initialValue || isOwner) && (
+          <button
+            className="bg-[#B91879] px-10 py-4 text-sm font-bold text-white hover:shadow-md"
+            type="submit"
+          >
+            Desar
+          </button>
+        )}
         <button
           className="border border-gray-600 px-10 py-4 text-sm font-bold text-gray-600 hover:shadow-md"
           type="button"

--- a/frontend/src/components/ticketing/TicketCommentForm.tsx
+++ b/frontend/src/components/ticketing/TicketCommentForm.tsx
@@ -18,12 +18,14 @@ const TicketCommentForm = ({
   date,
 }: Props) => {
   const [comment, setComment] = useState("");
+  const [editText, setEditText] = useState(initialValue ?? "");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!comment.trim()) return;
-    await onSubmit(comment);
-    setComment("");
+    const text = initialValue ? editText : comment;
+    if (!text.trim()) return;
+    await onSubmit(text);
+    if (!initialValue) setComment("");
   };
 
   const textareaClass =
@@ -35,9 +37,9 @@ const TicketCommentForm = ({
       {initialValue ? (
         <>
           <textarea
-            className={`${textareaClass} bg-gray-50`}
-            value={initialValue}
-            readOnly
+            className={textareaClass}
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
           />
           {(authorId || date) && (
             <p className="mt-1 text-xs text-gray-500">
@@ -54,14 +56,12 @@ const TicketCommentForm = ({
         />
       )}
       <div className="mt-4 flex gap-2">
-        {!initialValue && (
-          <button
-            className="bg-[#B91879] px-10 py-4 text-sm font-bold text-white hover:shadow-md"
-            type="submit"
-          >
-            Desar
-          </button>
-        )}
+        <button
+          className="bg-[#B91879] px-10 py-4 text-sm font-bold text-white hover:shadow-md"
+          type="submit"
+        >
+          Desar
+        </button>
         <button
           className="border border-gray-600 px-10 py-4 text-sm font-bold text-gray-600 hover:shadow-md"
           type="button"

--- a/frontend/src/components/ticketing/__test__/TicketCommentForm.test.tsx
+++ b/frontend/src/components/ticketing/__test__/TicketCommentForm.test.tsx
@@ -22,4 +22,23 @@ describe("TicketCommentForm", () => {
 
     expect(mockSubmit).toHaveBeenCalledWith("Nou comentari");
   });
+
+  it("calls onSubmit with updated text when editing an existing comment", async () => {
+    const mockSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TicketCommentForm
+        onSubmit={mockSubmit}
+        onClose={vi.fn()}
+        error={null}
+        initialValue="text original"
+      />,
+    );
+
+    fireEvent.change(screen.getByDisplayValue("text original"), {
+      target: { value: "text editat" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Desar" }));
+
+    expect(mockSubmit).toHaveBeenCalledWith("text editat");
+  });
 });

--- a/frontend/src/components/ticketing/__test__/TicketCommentForm.test.tsx
+++ b/frontend/src/components/ticketing/__test__/TicketCommentForm.test.tsx
@@ -23,7 +23,7 @@ describe("TicketCommentForm", () => {
     expect(mockSubmit).toHaveBeenCalledWith("Nou comentari");
   });
 
-  it("calls onSubmit with updated text when editing an existing comment", async () => {
+  it("calls onSubmit with updated text when editing own comment", async () => {
     const mockSubmit = vi.fn().mockResolvedValue(undefined);
     render(
       <TicketCommentForm
@@ -31,6 +31,8 @@ describe("TicketCommentForm", () => {
         onClose={vi.fn()}
         error={null}
         initialValue="text original"
+        authorId={123}
+        currentUserId={123}
       />,
     );
 


### PR DESCRIPTION
### Context
To implement comment editing simple and clean, we decided to make the existing comment textarea editable directly in the UI, rather than adding a separate "Edit" button mode. 
To prevent users from editing other teammates' comments, we check comment ownership (authorId === currentUserId). If the comment doesn't belong to the logged-in user, the textarea remains readOnly with a disabled visual style, and the submit button is hidden.


### Summary
- Added currentUserId prop and isOwner check to TicketCommentForm.tsx.
- Made the initialValue textarea editable and showed the "Desar" button only if isOwner is true.
- Retained the readOnly state and disabled background styling for comments belonging to other users.
- Added a happy path unit test in TicketCommentForm.test.tsx verifying the form submission with edited text for the owner.

Note for Reviewers / How to Test:
This PR only introduces the isolated UI component changes (PR 3 of 4). The page integration and hook connection will be done in the final sub-task (next PR). Therefore, this change cannot be tested in the browser yet (the comment will still appear as read-only on the page). Please verify this PR exclusively by running the unit tests.