### PR TITLE
feat(ticketing): add status filter to ticket list

### DIFF
--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -7,17 +7,10 @@ import { useCreateTicketing } from "../hooks/useCreateTicketing";
 import { useTicketingGetAll } from "../hooks/useTicketingGetAll";
 import { useTicketComments } from "../hooks/useTicketComments";
 import TicketList from "../components/tickets/TicketList";
+import { STATUS_LABELS } from "../components/tickets/ticketConstants";
 import type { IntCreateTicket, TicketStatus } from "../types/ticketingTypes";
 
 const DEFAULT_STATUSES: TicketStatus[] = ["pending", "in_progress"];
-
-const STATUS_LABELS: Record<TicketStatus, string> = {
-  pending: "Pendent",
-  in_progress: "En progrés",
-  blocked: "Bloquejat",
-  ready: "Llest",
-  closed: "Tancat",
-};
 
 const TicketingPage = (): JSX.Element => {
   const { submitTicketing } = useCreateTicketing();

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -7,12 +7,24 @@ import { useCreateTicketing } from "../hooks/useCreateTicketing";
 import { useTicketingGetAll } from "../hooks/useTicketingGetAll";
 import { useTicketComments } from "../hooks/useTicketComments";
 import TicketList from "../components/tickets/TicketList";
-import type { IntCreateTicket } from "../types/ticketingTypes";
+import type { IntCreateTicket, TicketStatus } from "../types/ticketingTypes";
+
+const DEFAULT_STATUSES: TicketStatus[] = ["pending", "in_progress"];
+
+const STATUS_LABELS: Record<TicketStatus, string> = {
+  pending: "Pendent",
+  in_progress: "En progrés",
+  blocked: "Bloquejat",
+  ready: "Llest",
+  closed: "Tancat",
+};
 
 const TicketingPage = (): JSX.Element => {
   const { submitTicketing } = useCreateTicketing();
   const { tickets, isLoading, errorMessage, refetch } = useTicketingGetAll();
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+  const [statusFilter, setStatusFilter] =
+    useState<TicketStatus[]>(DEFAULT_STATUSES);
   const {
     comments,
     error: commentError,
@@ -30,13 +42,49 @@ const TicketingPage = (): JSX.Element => {
     }
   };
 
+  const toggleStatus = (status: TicketStatus) => {
+    setStatusFilter((prev) =>
+      prev.includes(status)
+        ? prev.filter((s) => s !== status)
+        : [...prev, status],
+    );
+  };
+
+  const filteredTickets =
+    statusFilter.length === 0
+      ? tickets
+      : tickets.filter((t) => statusFilter.includes(t.status));
+
   return (
     <>
       <PageTitle title="Ticketing" />
       <Container className="xl:!px-16 md:!px-10 sm:!py-12 !px-6 !py-6">
         <TicketingCreateForm onSubmit={handleCreateTicket} />
+        <div className="flex gap-4 mb-4">
+          {(Object.keys(STATUS_LABELS) as TicketStatus[]).map((status) => (
+            <label
+              key={status}
+              className="flex items-center gap-2 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={statusFilter.includes(status)}
+                onChange={() => toggleStatus(status)}
+              />
+              <span className="text-sm">{STATUS_LABELS[status]}</span>
+            </label>
+          ))}
+          {statusFilter.length > 0 && (
+            <button
+              onClick={() => setStatusFilter([])}
+              className="text-sm text-blue-600 underline"
+            >
+              Mostrar tots
+            </button>
+          )}
+        </div>
         <TicketList
-          tickets={tickets}
+          tickets={filteredTickets}
           isLoading={isLoading}
           error={errorMessage}
           onCommentClick={setSelectedTicketId}

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -80,7 +80,7 @@ describe("TicketingPage", () => {
     expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
-  it("mostra només tickets pendents i en progrés per defecte", () => {
+  it("shows only pending and in-progress tickets by default", () => {
     const tickets = [
       { id: 1, status: "pending" },
       { id: 2, status: "in_progress" },

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -15,10 +15,16 @@ vi.mock("../../hooks/useCreateTicketing", () => ({
   useCreateTicketing: () => ({ submitTicketing: mockSubmitTicketing }),
 }));
 vi.mock("../../components/tickets/TicketList", () => ({
-  default: ({ isLoading, error }: TicketListProps) => {
+  default: ({ tickets, isLoading, error }: TicketListProps) => {
     if (isLoading) return <p>Carregant tickets...</p>;
     if (error) return <p>{error}</p>;
-    return <div data-testid="ticket-list" />;
+    return (
+      <div data-testid="ticket-list">
+        {tickets.map((t) => (
+          <div key={t.id} data-testid="ticket-list-item" />
+        ))}
+      </div>
+    );
   },
 }));
 vi.mock("../../components/ticketing/TicketingCreateForm", () => ({
@@ -71,5 +77,29 @@ describe("TicketingPage", () => {
     render(<TicketingPage />);
     await act(async () => fireEvent.click(screen.getByText("Crear ticket")));
     expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("mostra només tickets pendents i en progrés per defecte", () => {
+    const tickets = [
+      { id: 1, status: "pending" },
+      { id: 2, status: "in_progress" },
+      { id: 3, status: "closed" },
+    ] as any;
+    mockHook.mockReturnValue(hookReturn({ tickets }));
+    render(<TicketingPage />);
+    expect(screen.getAllByTestId("ticket-list-item")).toHaveLength(2);
+  });
+
+  it("toggles ticket filter when checkbox is clicked", () => {
+    const tickets = [
+      { id: 1, status: "pending" },
+      { id: 2, status: "in_progress" },
+      { id: 3, status: "blocked" },
+    ] as any;
+    mockHook.mockReturnValue(hookReturn({ tickets }));
+    render(<TicketingPage />);
+    const blockedCheckbox = screen.getByLabelText("Bloquejat");
+    fireEvent.click(blockedCheckbox);
+    expect(screen.getAllByTestId("ticket-list-item")).toHaveLength(3);
   });
 });

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import TicketingPage from "../TicketingPage";
 import { useTicketingGetAll } from "../../hooks/useTicketingGetAll";
+import type { ApiTicketData } from "../../types/ticketingTypes";
 import type {
   IntCreateTicket,
   TicketListProps,
@@ -84,7 +85,7 @@ describe("TicketingPage", () => {
       { id: 1, status: "pending" },
       { id: 2, status: "in_progress" },
       { id: 3, status: "closed" },
-    ] as any;
+    ] as ApiTicketData[];
     mockHook.mockReturnValue(hookReturn({ tickets }));
     render(<TicketingPage />);
     expect(screen.getAllByTestId("ticket-list-item")).toHaveLength(2);
@@ -95,7 +96,7 @@ describe("TicketingPage", () => {
       { id: 1, status: "pending" },
       { id: 2, status: "in_progress" },
       { id: 3, status: "blocked" },
-    ] as any;
+    ] as ApiTicketData[];
     mockHook.mockReturnValue(hookReturn({ tickets }));
     render(<TicketingPage />);
     const blockedCheckbox = screen.getByLabelText("Bloquejat");


### PR DESCRIPTION
Adding status filter checkbox status to filter the ticket list view. 
- Filter by ticket status (pending - "nou" in the table, in_progress, blocked, ready, closed). 
- By default, it shows only "pending" and "in_progress" tickets. "Mostrar tots" button allows viewing all tickets.

Implemented locally in React (no backend changes needed yet). 
- Shows only open tickets (pending + in_progress) to match issue requirement. 
- Using native checkboxes, no new components created (temporary solution before pagination and calling the API - Eventually, this filter should be deleted, eventually ..).

Only status filter implemented, other filters (priority, type) out of scope.

## Here is a sreenshot:
<img width="673" height="758" alt="Captura de pantalla 2026-06-04 a las 22 30 07" src="https://github.com/user-attachments/assets/72796e4b-e253-4c06-b319-e5bda2d604c8" />

