### PR TITLE
feat: add "Els meus projectes" button to CodeConnect dashboard

### DIFF
--- a/frontend/src/pages/CodeConnectPage.tsx
+++ b/frontend/src/pages/CodeConnectPage.tsx
@@ -9,6 +9,7 @@ import PageTitle from "../components/ui/PageTitle";
 const CodeConnectPage = () => {
   const navigate = useNavigate();
   const [filter, setFilter] = useState<string[]>([]);
+  const [showMyProjects, setShowMyProjects] = useState<boolean>(false);
 
   return (
     <>
@@ -18,7 +19,14 @@ const CodeConnectPage = () => {
           <h2 className="text-[26px] font-bold text-black text-left">
             Code Connect
           </h2>
-          <div className="py-3 sm:py-0">
+          <div className="flex items-center gap-3 py-3 sm:py-0">
+            <ButtonComponent
+              variant="custom"
+              className="text-primary font-[600] text-[14px] h-[41px] min-w-[152px] cursor-pointer hover:opacity-90"
+              onClick={() => setShowMyProjects(!showMyProjects)}
+            >
+              Els meus projectes
+            </ButtonComponent>
             <ButtonComponent
               variant="primary"
               onClick={() => navigate("/codeconnect/create")}

--- a/frontend/src/pages/__test__/CodeConnectPage.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectPage.test.tsx
@@ -54,18 +54,18 @@ describe("CodeConnectPage", () => {
   });
 
   it("renders My projects button", () => {
-  render(
-    <MemoryRouter initialEntries={["/codeconnect"]}>
-      <UserProvider>
-        <Routes>
-          <Route path="/codeconnect" element={<CodeConnectPage />} />
-        </Routes>
-      </UserProvider>
-    </MemoryRouter>,
-  );
+    render(
+      <MemoryRouter initialEntries={["/codeconnect"]}>
+        <UserProvider>
+          <Routes>
+            <Route path="/codeconnect" element={<CodeConnectPage />} />
+          </Routes>
+        </UserProvider>
+      </MemoryRouter>,
+    );
 
-  expect(
-    screen.getByRole("button", { name: /Els meus projectes/i })
-  ).toBeInTheDocument();
-});
+    expect(
+      screen.getByRole("button", { name: /Els meus projectes/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/__test__/CodeConnectPage.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectPage.test.tsx
@@ -52,4 +52,20 @@ describe("CodeConnectPage", () => {
 
     expect(screen.getByText("Create Code Connect Page")).toBeInTheDocument();
   });
+
+  it("renders My projects button", () => {
+  render(
+    <MemoryRouter initialEntries={["/codeconnect"]}>
+      <UserProvider>
+        <Routes>
+          <Route path="/codeconnect" element={<CodeConnectPage />} />
+        </Routes>
+      </UserProvider>
+    </MemoryRouter>,
+  );
+
+  expect(
+    screen.getByRole("button", { name: /Els meus projectes/i })
+  ).toBeInTheDocument();
+});
 });


### PR DESCRIPTION
**Description:**

Adds the "Els meus projectes" button to the CodeConnect dashboard header, next to the existing "Crear projecte" button.
Changes:

Added showMyProjects state to CodeConnectPage
Added "Els meus projectes" button with primary text color and no border

**Notes:**

Button has no functionality yet — filtering logic will be implemented in #733 (issue 2)

**Figma Image:**

<img width="793" height="172" alt="image" src="https://github.com/user-attachments/assets/5c7b490a-4a33-4295-82f9-e54facdbb131" />

**Project image:**

<img width="1375" height="293" alt="image" src="https://github.com/user-attachments/assets/e934befd-6afe-4060-af32-bceee1273cba" />
