### PR TITLE
Feature/767 add confirmation modal for weekly league transition

### DIFF
--- a/frontend/src/pages/LeaguesPage.tsx
+++ b/frontend/src/pages/LeaguesPage.tsx
@@ -4,15 +4,32 @@ import LeagueToggle, {
 } from "../components/leagues-ranking/LeagueToggle/LeagueToggle";
 import { GlobalRanking } from "../components/leagues-ranking/GlobalRanking/GlobalRanking";
 import { WeeklyRanking } from "../components/leagues-ranking/WeeklyRanking/WeeklyRanking";
+import GenericModal from "../components/ui/Modal/GenericModal";
 
 const LeaguesPage = () => {
   const [view, setView] = useState<LeagueView>("weekly");
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
     <div className="px-6 md:px-10 xl:px-20 2xl:px-6 flex flex-col gap-10">
       <LeagueToggle view={view} onChange={setView} />
+      <button onClick={() => setIsModalOpen(true)}>Trigger</button>
+      <GenericModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="Actualitzar lligues"
+        showPrimaryButton
+        primaryButtonText="Confirmar"
+        primaryButtonAction={() => setIsModalOpen(false)}
+        showSecondaryButton
+        secondaryButtonText="Cancel·lar"
+        secondaryButtonAction={() => setIsModalOpen(false)}
+      >
+        <p>Vols actualitzar les lligues?</p>
+      </GenericModal>
+
       {view === "weekly" ? <WeeklyRanking /> : <GlobalRanking />}
-    </div>
+    </div >
   );
 };
 

--- a/frontend/src/pages/LeaguesPage.tsx
+++ b/frontend/src/pages/LeaguesPage.tsx
@@ -29,7 +29,7 @@ const LeaguesPage = () => {
       </GenericModal>
 
       {view === "weekly" ? <WeeklyRanking /> : <GlobalRanking />}
-    </div >
+    </div>
   );
 };
 

--- a/frontend/src/pages/__test__/LeaguesPage.test.tsx
+++ b/frontend/src/pages/__test__/LeaguesPage.test.tsx
@@ -12,6 +12,23 @@ vi.mock("../../components/leagues-ranking/GlobalRanking/GlobalRanking", () => ({
   GlobalRanking: () => <h1>Classificació general</h1>,
 }));
 
+vi.mock("../../components/ui/Modal/GenericModal", () => ({
+  default: ({
+    isOpen,
+    secondaryButtonAction,
+    secondaryButtonText,
+  }: {
+    isOpen: boolean;
+    secondaryButtonAction?: () => void;
+    secondaryButtonText?: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog">
+        <button onClick={secondaryButtonAction}>{secondaryButtonText}</button>
+      </div>
+    ) : null,
+}));
+
 describe("LeaguesPage", () => {
   it("shows WeeklyRanking by default", () => {
     render(<LeaguesPage />);
@@ -45,5 +62,18 @@ describe("LeaguesPage", () => {
     expect(
       screen.getByRole("heading", { name: /lliga setmanal/i }),
     ).toBeInTheDocument();
+  });
+
+  it("opens modal when trigger button is clicked", () => {
+    render(<LeaguesPage />);
+    fireEvent.click(screen.getByRole("button", { name: /trigger/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("closes modal when cancel button is clicked", () => {
+    render(<LeaguesPage />);
+    fireEvent.click(screen.getByRole("button", { name: /trigger/i }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel·lar/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a confirmation modal to LeaguesPage using GenericModal component
- Trigger button is hardcoded temporarily (pending merge of #772 which adds the proper role-based button)
- Modal can be confirmed or cancelled
- Added tests for modal open/close behaviour

<img width="599" height="384" alt="Captura de pantalla 2026-06-05 a las 12 20 11" src="https://github.com/user-attachments/assets/06605e11-d4e0-45d1-8937-7311d3a10d2c" />
