### PR TITLE
Feature/add confirmation modal

### DIFF
--- a/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
+++ b/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
@@ -5,6 +5,7 @@ import TeamRow from "./TeamRow";
 import { useProjectContributors } from "../../../hooks/useProjectContributors";
 import { ApiProjectContributor } from "../../../types/codeConnectTypes";
 import { joinProject } from "../../../api/endPointContributors";
+import GenericModal from "../../ui/Modal/GenericModal";
 
 interface ProjectTeamProps {
   logoFront?: string;
@@ -29,7 +30,9 @@ function ProjectTeam({
   );
   const [selectedRole, setSelectedRole] = useState<
     "Frontend Developer" | "Backend Developer" | null
-  >(null);
+    > (null);
+  
+  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
 
   const handleSlotClick = (
     role: "Frontend Developer" | "Backend Developer",
@@ -116,6 +119,32 @@ function ProjectTeam({
           Apuntar-me
         </ButtonComponent>
       </div>
+            <div className="w-full flex justify-center -mt-8 ">
+        <ButtonComponent
+          className="my-5 w-full"
+          type="button"
+          variant="custom"
+          onClick={() => setIsLeaveModalOpen(true)}
+        >
+          deixar projecte
+        </ButtonComponent>
+      </div>
+
+      {isLeaveModalOpen && (
+        <GenericModal
+  isOpen={isLeaveModalOpen}
+  onClose={() => setIsLeaveModalOpen(false)}
+  title="Deixar projecte"
+  showPrimaryButton
+  primaryButtonText="Confirmar"
+  primaryButtonAction={() => setIsLeaveModalOpen(false)}
+  showSecondaryButton
+  secondaryButtonText="Cancel·lar"
+  secondaryButtonAction={() => setIsLeaveModalOpen(false)}
+>
+  <p>Segur que vols deixar aquest projecte?</p>
+</GenericModal>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
+++ b/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
@@ -30,8 +30,8 @@ function ProjectTeam({
   );
   const [selectedRole, setSelectedRole] = useState<
     "Frontend Developer" | "Backend Developer" | null
-    > (null);
-  
+  >(null);
+
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
 
   const handleSlotClick = (
@@ -119,7 +119,7 @@ function ProjectTeam({
           Apuntar-me
         </ButtonComponent>
       </div>
-            <div className="w-full flex justify-center -mt-8 ">
+      <div className="w-full flex justify-center -mt-8 ">
         <ButtonComponent
           className="my-5 w-full"
           type="button"
@@ -132,18 +132,18 @@ function ProjectTeam({
 
       {isLeaveModalOpen && (
         <GenericModal
-  isOpen={isLeaveModalOpen}
-  onClose={() => setIsLeaveModalOpen(false)}
-  title="Deixar projecte"
-  showPrimaryButton
-  primaryButtonText="Confirmar"
-  primaryButtonAction={() => setIsLeaveModalOpen(false)}
-  showSecondaryButton
-  secondaryButtonText="Cancel·lar"
-  secondaryButtonAction={() => setIsLeaveModalOpen(false)}
->
-  <p>Segur que vols deixar aquest projecte?</p>
-</GenericModal>
+          isOpen={isLeaveModalOpen}
+          onClose={() => setIsLeaveModalOpen(false)}
+          title="Deixar projecte"
+          showPrimaryButton
+          primaryButtonText="Confirmar"
+          primaryButtonAction={() => setIsLeaveModalOpen(false)}
+          showSecondaryButton
+          secondaryButtonText="Cancel·lar"
+          secondaryButtonAction={() => setIsLeaveModalOpen(false)}
+        >
+          <p>Segur que vols deixar aquest projecte?</p>
+        </GenericModal>
       )}
     </div>
   );

--- a/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
+++ b/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
@@ -39,13 +39,16 @@ describe("ProjectTeam Component", () => {
 
   it("opens the leave project modal and closes it with the cancel button", () => {
     render(<ProjectTeam timeDuration="2 mesos" />);
-    const leaveProjectButton = screen.getByRole("button", {name: /deixar projecte/i,});
+    const leaveProjectButton = screen.getByRole("button", {
+      name: /deixar projecte/i,
+    });
     fireEvent.click(leaveProjectButton);
     expect(screen.getByText("Deixar projecte")).toBeInTheDocument();
-    expect(screen.getByText("Segur que vols deixar aquest projecte?"),).toBeInTheDocument();
-    const cancelButton = screen.getByRole("button", {name: /cancel/i,});
+    expect(
+      screen.getByText("Segur que vols deixar aquest projecte?"),
+    ).toBeInTheDocument();
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
     fireEvent.click(cancelButton);
     expect(screen.queryByText("Deixar projecte")).not.toBeInTheDocument();
   });
 });
-

--- a/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
+++ b/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
@@ -36,4 +36,16 @@ describe("ProjectTeam Component", () => {
     fireEvent.click(emptySlots[0]);
     expect(button).not.toBeDisabled();
   });
+
+  it("opens the leave project modal and closes it with the cancel button", () => {
+    render(<ProjectTeam timeDuration="2 mesos" />);
+    const leaveProjectButton = screen.getByRole("button", {name: /deixar projecte/i,});
+    fireEvent.click(leaveProjectButton);
+    expect(screen.getByText("Deixar projecte")).toBeInTheDocument();
+    expect(screen.getByText("Segur que vols deixar aquest projecte?"),).toBeInTheDocument();
+    const cancelButton = screen.getByRole("button", {name: /cancel/i,});
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText("Deixar projecte")).not.toBeInTheDocument();
+  });
 });
+


### PR DESCRIPTION
## Summary

Create a confirmation modal for the **deixar projecte** action.

_"As a student, I want to be prompted for confirmation before leaving a project so I do not leave by mistake."_

The modal gives the student a chance to confirm the action or cancel and stay in the project.

## What Changed

- Added a **deixar projecte** button to `ProjectTeam`.
- Added a confirmation modal that opens when clicking **deixar projecte**.
- Added cancel/confirm buttons inside the modal.
- Added a test to verify the modal opens and closes with the cancel action.

## Out Of Scope

- Wiring the confirm button to the leave-project API.
- Actually removing the student from the project.

> Note For now, both **Confirmar** and **Cancel·lar** close the modal. The real leave-project behavior will be handled in a separate branch.

## Test

```bash
npx vitest run src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
```

<img width="506" height="315" alt="Screenshot 2026-06-05 123008" src="https://github.com/user-attachments/assets/d9aeaa19-b0ae-41e8-a854-2b57ecb3b825" />