### PR TITLE
Feature/725 ticketing - add editComment to useTicketComments with happy path test

### DIFF
--- a/frontend/src/api/endPointTickets.ts
+++ b/frontend/src/api/endPointTickets.ts
@@ -77,3 +77,25 @@ export const addComment = async (
 
   return response.data.data;
 };
+
+export const updateComment = async (
+  ticketId: number,
+  commentId: number,
+  comment: string,
+): Promise<TicketComment> => {
+  const token = localStorage.getItem("auth_token");
+  const url = `${API_URL}tickets/${ticketId}/comments/${commentId}`;
+
+  const response = await axios.put<{ data: TicketComment }>(
+    url,
+    { comment },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  return response.data.data;
+};

--- a/frontend/src/hooks/__tests__/useTicketComments.test.ts
+++ b/frontend/src/hooks/__tests__/useTicketComments.test.ts
@@ -3,20 +3,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useTicketComments } from "../useTicketComments";
 
-const { mockGetComments, mockAddComment } = vi.hoisted(() => ({
-  mockGetComments: vi.fn(),
-  mockAddComment: vi.fn(),
-}));
+const { mockGetComments, mockAddComment, mockUpdateComment } = vi.hoisted(
+  () => ({
+    mockGetComments: vi.fn(),
+    mockAddComment: vi.fn(),
+    mockUpdateComment: vi.fn(),
+  }),
+);
 
 vi.mock("../../api/endPointTickets", () => ({
   getComments: mockGetComments,
   addComment: mockAddComment,
+  updateComment: mockUpdateComment,
 }));
 
 describe("useTicketComments", () => {
   beforeEach(() => {
     mockGetComments.mockClear();
     mockAddComment.mockClear();
+    mockUpdateComment.mockClear();
   });
 
   it("should fetch comments on mount", async () => {
@@ -40,5 +45,21 @@ describe("useTicketComments", () => {
 
     await result.current.submitComment("Hello");
     expect(mockAddComment).toHaveBeenCalledWith(1, "Hello");
+  });
+
+  it("should update comment in local state after editComment", async () => {
+    const original = { id: 1, comment: "old text", user_id: 1 };
+    const updated = { id: 1, comment: "new text", user_id: 1 };
+    mockGetComments.mockResolvedValue([original]);
+    mockUpdateComment.mockResolvedValue(updated);
+
+    const { result } = renderHook(() => useTicketComments(1));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await result.current.editComment(1, "new text");
+
+    await waitFor(() =>
+      expect(result.current.comments[0].comment).toBe("new text"),
+    );
   });
 });

--- a/frontend/src/hooks/useTicketComments.ts
+++ b/frontend/src/hooks/useTicketComments.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { addComment, getComments } from "../api/endPointTickets";
+import { addComment, getComments, updateComment } from "../api/endPointTickets";
 import type { TicketComment } from "../types/ticketingTypes";
 
 export const useTicketComments = (ticketId: number) => {
@@ -36,5 +36,19 @@ export const useTicketComments = (ticketId: number) => {
     [ticketId],
   );
 
-  return { comments, isLoading, error, submitComment };
+  const editComment = useCallback(
+    async (commentId: number, newText: string) => {
+      try {
+        const updated = await updateComment(ticketId, commentId, newText);
+        setComments((prev) =>
+          prev.map((c) => (c.id === commentId ? updated : c)),
+        );
+      } catch {
+        setError("Error en actualitzar el comentari");
+      }
+    },
+    [ticketId],
+  );
+
+  return { comments, isLoading, error, submitComment, editComment };
 };


### PR DESCRIPTION
## Context
The hook useTicketComments currently only exposes submitComment to create new comments. This PR adds editComment, a new function that calls the PUT /tickets/{ticketId}/comments/{commentId} endpoint and updates the comment in the local state without reloading the page.

IMPORTANT
About the dependency with PR #769 : This PR needs updateComment from endPointTickets.ts, which is being added in this previous PR waiting for approbal. 
I've copied the same function here temporarily so this PR can compile and be tested on its own. When PR 1 merges into develop, there will be a small conflict on that file, but since the code is the same it's a 2-second fix.

## Summary
- Copied updateComment into endPointTickets.ts temporarily (same code as PR 1) so the hook can import it
- Added editComment to useTicketComments.ts
- Updated the test file with the new mock and a happy path test

## How to Test

IMPORTANT
This PR only covers the hook. It's not connected to the UI yet — that's PR 4. You can't test it in the browser yet.

Go to the frontend folder:
```bash
cd frontend
```
Run the tests:
```bash
npx vitest run src/hooks/__tests__/useTicketComments.test.ts
```
Check that all 3 pass:
should fetch comments on mount
should call addComment with ticketId and comment text
should update comment in local state after editComment ← thi is new
