### PR TITLE
feat(#766): add POST endpoint to manually trigger weekly league transition

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -8,12 +8,14 @@ use App\Models\Liga;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
 
 class LigaController extends Controller
 {
     public function __construct()
     {
     $this->middleware('check.permission:add liga points')->only(['addPoints']);
+    $this->middleware('check.permission:trigger weekly transition')->only(['triggerWeeklyTransition']);
     }
 
 
@@ -96,5 +98,12 @@ class LigaController extends Controller
         ]);
     }
 
+    public function triggerWeeklyTransition(): JsonResponse
+    {
+        Artisan::call('liga:reset-weekly');
+        return response()->json([
+            'message' => 'Weekly transition triggered successfully',
+        ]);
+    }
 }
 

--- a/backend/src/database/seeders/PermissionSeeder.php
+++ b/backend/src/database/seeders/PermissionSeeder.php
@@ -51,6 +51,7 @@ class PermissionSeeder extends Seeder
 
         // Permisos - Liga
         Permission::firstOrCreate(['name' => 'add liga points', 'guard_name' => 'api']);
+        Permission::firstOrCreate(['name' => 'trigger weekly transition', 'guard_name' => 'api']);
        
         $this->command->info('✅ Permissions created successfully!');
         $this->command->info('Total permissions: ' . Permission::count());

--- a/backend/src/database/seeders/RolePermissionSeeder.php
+++ b/backend/src/database/seeders/RolePermissionSeeder.php
@@ -73,6 +73,7 @@ class RolePermissionSeeder extends Seeder
                 'update ticket priority',
                 'assign tickets',
                 'add liga points',
+                'trigger weekly transition',
             ],
 
             'admin' => [
@@ -99,6 +100,7 @@ class RolePermissionSeeder extends Seeder
                 'assign tickets',
                 'add closing comment',
                 'add liga points',
+                'trigger weekly transition',
             ],
 
             'superadmin' => 'all',  // Special marker for all permissions

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -182,4 +182,6 @@ Route::get('/ligas/ranking', [LigaController::class, 'ranking'])->name('ligas.ra
 Route::middleware('auth:sanctum')->group(function () {
     Route::put('/ligas/{user}/points', [LigaController::class, 'addPoints'])->name('ligas.points.add');
     Route::post('/ligas', [LigaController::class, 'store'])->name('ligas.store');
+
+    Route::post('/liga/trigger-weekly-transition', [LigaController::class, 'triggerWeeklyTransition'])->name('liga.trigger-weekly-transition');
 });

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -183,5 +183,5 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::put('/ligas/{user}/points', [LigaController::class, 'addPoints'])->name('ligas.points.add');
     Route::post('/ligas', [LigaController::class, 'store'])->name('ligas.store');
 
-    Route::post('/liga/trigger-weekly-transition', [LigaController::class, 'triggerWeeklyTransition'])->name('liga.trigger-weekly-transition');
+    Route::post('/ligas/trigger-weekly-transition', [LigaController::class, 'triggerWeeklyTransition'])->name('ligas.trigger-weekly-transition');
 });

--- a/backend/src/tests/Feature/LigaTests/LigaTriggerWeeklyTransitionTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaTriggerWeeklyTransitionTest.php
@@ -21,7 +21,7 @@ class LigaTriggerWeeklyTransitionTest extends TestCase
             'points' => 10,
             'points_weekly' => 10,
         ]);
-        $response = $this->postJson('/api/liga/trigger-weekly-transition');
+        $response = $this->postJson('/api/ligas/trigger-weekly-transition');
         $response->assertStatus(200);
         $this->assertDatabaseHas('ligas', ['user_id' => $user->id, 'points' => 10, 'points_weekly' => 0,]);
     }
@@ -29,13 +29,13 @@ class LigaTriggerWeeklyTransitionTest extends TestCase
     public function test_student_cannot_trigger_weekly_transition(): void
     {
         $user = $this->authenticateUserWithRole('student');
-        $response = $this->postJson('/api/liga/trigger-weekly-transition');
+        $response = $this->postJson('/api/ligas/trigger-weekly-transition');
         $response->assertStatus(403);
     }
 
     public function test_unauthenticated_user_cannot_trigger_weekly_transition(): void
     {
-        $response = $this->postJson('/api/liga/trigger-weekly-transition');
+        $response = $this->postJson('/api/ligas/trigger-weekly-transition');
         $response->assertStatus(401);
     }
 }

--- a/backend/src/tests/Feature/LigaTests/LigaTriggerWeeklyTransitionTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaTriggerWeeklyTransitionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Liga;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaTriggerWeeklyTransitionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mentor_can_trigger_weekly_transition(): void
+    {
+        $user = $this->authenticateUserWithRole('mentor');
+        Liga::create([
+            'user_id' => $user->id,
+            'points' => 10,
+            'points_weekly' => 10,
+        ]);
+        $response = $this->postJson('/api/liga/trigger-weekly-transition');
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('ligas', ['user_id' => $user->id, 'points' => 10, 'points_weekly' => 0,]);
+    }
+
+    public function test_student_cannot_trigger_weekly_transition(): void
+    {
+        $user = $this->authenticateUserWithRole('student');
+        $response = $this->postJson('/api/liga/trigger-weekly-transition');
+        $response->assertStatus(403);
+    }
+
+    public function test_unauthenticated_user_cannot_trigger_weekly_transition(): void
+    {
+        $response = $this->postJson('/api/liga/trigger-weekly-transition');
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
  ## Summary

- Adds POST /api/liga/trigger-weekly-transition endpoint in LigaController
- Calls existing liga:reset-weekly Artisan command
- Protected by check.permission middleware (admin, mentor, superadmin only)
- Adds trigger weekly transition permission to PermissionSeeder and RolePermissionSeeder
- Adds feature tests for mentor (200), student (403) and unauthenticated (401)