### PR TITLE
Feat/get user points history

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\Liga;
+use App\Models\LigaPointHistory;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -66,6 +67,15 @@ class LigaController extends Controller
             ]);
 
         return response()->json($entries);
+    }
+
+    public function history(): JsonResponse
+    {
+        $history = LigaPointHistory::where('user_id', auth()->id())
+            ->orderBy('created_at', 'asc')
+            ->get(['points', 'activity', 'created_at']);
+
+        return response()->json($history);
     }
 
     public function addPoints(Request $request, User $user): JsonResponse

--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -73,7 +73,7 @@ class LigaController extends Controller
     {
         $history = LigaPointHistory::where('user_id', auth()->id())
             ->orderBy('created_at', 'asc')
-            ->get(['points', 'activity', 'created_at']);
+            ->get(['points', 'activity', 'created_at as date']);
 
         return response()->json($history);
     }

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -182,4 +182,5 @@ Route::get('/ligas/ranking', [LigaController::class, 'ranking'])->name('ligas.ra
 Route::middleware('auth:sanctum')->group(function () {
     Route::put('/ligas/{user}/points', [LigaController::class, 'addPoints'])->name('ligas.points.add');
     Route::post('/ligas', [LigaController::class, 'store'])->name('ligas.store');
+    Route::get('/ligas/history', [LigaController::class, 'history'])->name('ligas.history');
 });

--- a/backend/src/tests/Feature/LigaTests/LigaGetHistoryTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaGetHistoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\LigaTests;
+
+use App\Models\LigaPointHistory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaGetHistoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_get_their_history(): void
+    {
+        $user = $this->authenticateUserWithRole('student');
+
+        LigaPointHistory::create([
+            'user_id'  => $user->id,
+            'points'   => 5,
+            'activity' => 'Resolució de Dubtes',
+        ]);
+
+        $response = $this->getJson('/api/ligas/history');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1)
+            ->assertJsonStructure([
+                '*' => ['points', 'activity', 'created_at'],
+            ]);
+    }
+
+    public function test_unauthenticated_user_cannot_get_history(): void
+    {
+        $response = $this->getJson('/api/ligas/history');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_history_only_returns_entries_for_authenticated_user(): void
+    {
+        $user = $this->authenticateUserWithRole('student');
+        $otherUser = User::factory()->create();
+
+        LigaPointHistory::create(['user_id' => $user->id, 'points' => 10, 'activity' => 'Presentació']);
+        LigaPointHistory::create(['user_id' => $otherUser->id, 'points' => 20, 'activity' => 'Correcció de PR']);
+
+        $response = $this->getJson('/api/ligas/history');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1);
+    }
+}

--- a/backend/src/tests/Feature/LigaTests/LigaGetHistoryTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaGetHistoryTest.php
@@ -52,4 +52,22 @@ class LigaGetHistoryTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonCount(1);
     }
+
+    public function test_history_is_returned_in_chronological_order(): void
+    {
+        $user = $this->authenticateUserWithRole('student');
+
+        LigaPointHistory::create(['user_id' => $user->id, 'points' => 20, 'activity' => 'Presentació', 'created_at' => now()->subDays(2)]);
+        LigaPointHistory::create(['user_id' => $user->id, 'points' => 10, 'activity' => 'Correcció de PR', 'created_at' => now()->subDay()]);
+        LigaPointHistory::create(['user_id' => $user->id, 'points' => 5, 'activity' => 'Resolució de Dubtes', 'created_at' => now()]);
+
+        $response = $this->getJson('/api/ligas/history');
+
+        $response->assertStatus(200);
+
+        $data = $response->json();
+        $this->assertEquals(20, $data[0]['points']);
+        $this->assertEquals(10, $data[1]['points']);
+        $this->assertEquals(5, $data[2]['points']);
+    }
 }

--- a/backend/src/tests/Feature/LigaTests/LigaGetHistoryTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaGetHistoryTest.php
@@ -28,7 +28,7 @@ class LigaGetHistoryTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonCount(1)
             ->assertJsonStructure([
-                '*' => ['points', 'activity', 'created_at'],
+                '*' => ['points', 'activity', 'date'],
             ]);
     }
 


### PR DESCRIPTION
### **Summary**

- Adds `GET /ligas/history` endpoint that returns the authenticated user's points history in chronological order      
- Each entry includes `points`, `activity` and `created_at`                                                               
- Endpoint is protected by Sanctum. Only authenticated users can access it

### **Test plan**

- [x] Run `docker exec backend php artisan test src/tests/Feature/LigaTests/LigaGetHistoryTest.php` -  3 tests pass
- [x] Verify authenticated user receives only their own entries
- [x] Verify unauthenticated request returns 401