### PR TITLE
feat(#767): add trigger weekly transition API call and hook

### DIFF
--- a/frontend/src/api/endPointLeagues.ts
+++ b/frontend/src/api/endPointLeagues.ts
@@ -32,3 +32,21 @@ export const fetchLeagueRanking = async (
     throw error;
   }
 };
+
+export const triggerWeeklyTransition = async (): Promise<void> => {
+  const url = `${API_URL}${END_POINTS.leagues.triggerWeeklyTransition}`;
+  const token = localStorage.getItem("authToken");
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) throw new Error("Failed to trigger weekly transition");
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -17,7 +17,8 @@ type EndPoints =
   | "auth"
   | "tickets"
   | "ligas"
-  | "ligas/ranking";
+  | "ligas/ranking"
+  | "ligas/trigger-weekly-transition";
 
 const END_POINTS = {
   resources: {
@@ -71,6 +72,7 @@ const END_POINTS = {
     getWeekly: "ligas" as EndPoints,
     post: "ligas" as EndPoints,
     addPoints: "ligas" as EndPoints,
+    triggerWeeklyTransition: "ligas/trigger-weekly-transition" as EndPoints,
   },
 };
 

--- a/frontend/src/hooks/__tests__/useTriggerWeeklyTransition.test.ts
+++ b/frontend/src/hooks/__tests__/useTriggerWeeklyTransition.test.ts
@@ -1,0 +1,22 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useTriggerWeeklyTransition } from "../useTriggerWeeklyTransition";
+
+describe("useTriggerWeeklyTransition", () => {
+  it("should trigger weekly transition successfully", async () => {
+    const mockTriggerWeeklyTransition = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useTriggerWeeklyTransition({
+        triggerWeeklyTransition: mockTriggerWeeklyTransition,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.trigger();
+    });
+
+    expect(mockTriggerWeeklyTransition).toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useTriggerWeeklyTransition.ts
+++ b/frontend/src/hooks/useTriggerWeeklyTransition.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+type UseTriggerWeeklyTransition = {
+  triggerWeeklyTransition: () => Promise<void>;
+};
+
+type UseTriggerWeeklyTransitionReturn = {
+  trigger: () => Promise<void>;
+  error: string | null;
+  isLoading: boolean;
+};
+
+export const useTriggerWeeklyTransition = ({
+  triggerWeeklyTransition,
+}: UseTriggerWeeklyTransition): UseTriggerWeeklyTransitionReturn => {
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const trigger = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await triggerWeeklyTransition();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { trigger, error, isLoading };
+};


### PR DESCRIPTION
## Summary

  - Adds `triggerWeeklyTransition` function in `endPointLeagues.ts` to call `POST /api/ligas/trigger-weekly-transition`
  - Adds `useTriggerWeeklyTransition` hook to manage loading and error state
  - Adds unit test for the hook (happy path)

Note: PR exceeds 50 lines but all additions are new files (API function, hook and test).