### PR TITLE
Feature/render button by contributor

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -183,6 +183,8 @@ class ListProjectsController extends Controller
             'owner' => $this->formatOwner($project->user),
             'contributors' => $project->contributorListProject->map(function ($contributor) {
                 return [
+                    'id' => $contributor->id,
+                    'user_id' => $contributor->user_id,
                     'name' => $contributor->user->name,
                     'programming_role' => $contributor->programming_role,
                     'avatar_url' => $contributor->user->avatar_url,

--- a/backend/src/tests/Feature/ListProjects/ListProjectsShowTest.php
+++ b/backend/src/tests/Feature/ListProjects/ListProjectsShowTest.php
@@ -73,6 +73,8 @@ class ListProjectsShowTest extends TestCase
                 ],
                 'contributors' => [
                     [
+                        'id' => $this->contributorOne->id,
+                        'user_id' => $this->contributorOne->user_id,
                         'name' => $this->contributorOne->user->name,
                         'programming_role' => $this->contributorOne->programming_role,
                         'avatar_url' => $this->contributorOne->user->avatar_url,

--- a/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
+++ b/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
@@ -13,6 +13,7 @@ interface ProjectTeamProps {
   contributors?: ApiProjectContributor[];
   timeDuration?: string;
   projectId?: number;
+  projectOwnerId?: number;
 }
 
 function ProjectTeam({
@@ -21,6 +22,7 @@ function ProjectTeam({
   contributors = [],
   timeDuration,
   projectId,
+  projectOwnerId,
 }: ProjectTeamProps) {
   const { getTeamByRole } = useProjectContributors(contributors);
   const frontendData = getTeamByRole("frontend");
@@ -48,10 +50,14 @@ function ProjectTeam({
   const frontendOffset = 0;
   const backendOffset = frontendData.emptySlots;
   const currentUserId = getCurrentUserId();
+  const isProjectOwner = currentUserId === projectOwnerId;
 
   const currentUserContributor = contributors.find(
     (contributor) => contributor.user_id === currentUserId,
   );
+
+  const shouldShowLeaveButton =
+    Boolean(currentUserContributor) && !isProjectOwner;
 
   return (
     <div className="flex flex-col items-start border border-gray-500 text-black w-80 pt-7 pb-10 px-6 rounded-3xl max-h-[700px]">
@@ -122,7 +128,7 @@ function ProjectTeam({
         >
           Apuntar-me
         </ButtonComponent>
-        {currentUserContributor && (
+        {shouldShowLeaveButton && (
           <div className="w-full flex justify-center -mt-8">
             <ButtonComponent
               className="my-5 w-full"

--- a/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
+++ b/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
@@ -5,6 +5,7 @@ import TeamRow from "./TeamRow";
 import { useProjectContributors } from "../../../hooks/useProjectContributors";
 import { ApiProjectContributor } from "../../../types/codeConnectTypes";
 import { joinProject } from "../../../api/endPointContributors";
+import { getCurrentUserId } from "../../../utils/getCurrentUserId";
 
 interface ProjectTeamProps {
   logoFront?: string;
@@ -43,8 +44,14 @@ function ProjectTeam({
     if (!selectedRole || !projectId) return;
     await joinProject(projectId, selectedRole);
   };
+
   const frontendOffset = 0;
   const backendOffset = frontendData.emptySlots;
+  const currentUserId = getCurrentUserId();
+
+  const currentUserContributor = contributors.find(
+    (contributor) => contributor.user_id === currentUserId,
+  );
 
   return (
     <div className="flex flex-col items-start border border-gray-500 text-black w-80 pt-7 pb-10 px-6 rounded-3xl max-h-[700px]">
@@ -115,6 +122,20 @@ function ProjectTeam({
         >
           Apuntar-me
         </ButtonComponent>
+        {currentUserContributor && (
+          <div className="w-full flex justify-center -mt-8">
+            <ButtonComponent
+              className="my-5 w-full"
+              type="button"
+              variant="secondary" //should change to discret
+              onClick={() => {
+                // delete call will go here later
+              }}
+            >
+              Deixar projecte
+            </ButtonComponent>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
+++ b/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
@@ -5,7 +5,7 @@ import TeamRow from "./TeamRow";
 import { useProjectContributors } from "../../../hooks/useProjectContributors";
 import { ApiProjectContributor } from "../../../types/codeConnectTypes";
 import { joinProject } from "../../../api/endPointContributors";
-import { getCurrentUserId } from "../../../utils/getCurrentUserId";
+import { useUserContext } from "../../../context/UserContext";
 
 interface ProjectTeamProps {
   logoFront?: string;
@@ -24,6 +24,7 @@ function ProjectTeam({
   projectId,
   projectOwnerId,
 }: ProjectTeamProps) {
+  const { user } = useUserContext();
   const { getTeamByRole } = useProjectContributors(contributors);
   const frontendData = getTeamByRole("frontend");
   const backendData = getTeamByRole("backend");
@@ -49,7 +50,7 @@ function ProjectTeam({
 
   const frontendOffset = 0;
   const backendOffset = frontendData.emptySlots;
-  const currentUserId = getCurrentUserId();
+  const currentUserId = user?.id;
   const isProjectOwner = currentUserId === projectOwnerId;
 
   const currentUserContributor = contributors.find(

--- a/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
+++ b/frontend/src/components/code-connect/projectTeam/ProjectTeam.tsx
@@ -6,6 +6,7 @@ import { useProjectContributors } from "../../../hooks/useProjectContributors";
 import { ApiProjectContributor } from "../../../types/codeConnectTypes";
 import { joinProject } from "../../../api/endPointContributors";
 import GenericModal from "../../ui/Modal/GenericModal";
+import { useUserContext } from "../../../context/UserContext";
 
 interface ProjectTeamProps {
   logoFront?: string;
@@ -136,25 +137,13 @@ function ProjectTeam({
             <ButtonComponent
               className="my-5 w-full"
               type="button"
-              variant="secondary" //should change to discret
-              onClick={() => {
-                // delete call will go here later
-              }}
+              variant="discreet"
+              onClick={() => setIsLeaveModalOpen(true)}
             >
               Deixar projecte
             </ButtonComponent>
           </div>
         )}
-      </div>
-      <div className="w-full flex justify-center -mt-8 ">
-        <ButtonComponent
-          className="my-5 w-full"
-          type="button"
-          variant="discreet"
-          onClick={() => setIsLeaveModalOpen(true)}
-        >
-          Deixar projecte
-        </ButtonComponent>
       </div>
 
       {isLeaveModalOpen && (

--- a/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
+++ b/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
@@ -73,11 +73,16 @@ describe("ProjectTeam Component", () => {
     );
     expect(
       screen.queryByRole("button", { name: /deixar projecte/i }),
-         ).not.toBeInTheDocument();
+    ).not.toBeInTheDocument();
   });
-  
+
   it("renders leave project button", () => {
-    render(<ProjectTeam timeDuration="2 mesos" />);
+    render(
+      <ProjectTeam
+        timeDuration="2 mesos"
+        contributors={[currentUserContributor]}
+      />,
+    );
 
     expect(
       screen.getByRole("button", { name: /Deixar projecte/i }),
@@ -85,7 +90,12 @@ describe("ProjectTeam Component", () => {
   });
 
   it("opens the leave project modal and closes it with the cancel button", () => {
-    render(<ProjectTeam timeDuration="2 mesos" />);
+    render(
+      <ProjectTeam
+        timeDuration="2 mesos"
+        contributors={[currentUserContributor]}
+      />,
+    );
     const leaveProjectButton = screen.getByRole("button", {
       name: /Deixar projecte/i,
     });
@@ -100,4 +110,6 @@ describe("ProjectTeam Component", () => {
     fireEvent.click(cancelButton);
     expect(
       screen.queryByRole("heading", { name: "Deixar projecte" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
+++ b/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
@@ -17,6 +17,14 @@ vi.mock("../../../../utils/getCurrentUserId", () => ({
   getCurrentUserId: () => 7,
 }));
 
+const currentUserContributor = {
+  id: 12,
+  user_id: 7,
+  name: "Clara",
+  programming_role: "Frontend Developer" as const,
+  avatar_url: null,
+};
+
 describe("ProjectTeam Component", () => {
   it("renderitza els títols, la durada i les seccions", () => {
     render(<ProjectTeam timeDuration="2 mesos" />);
@@ -45,20 +53,24 @@ describe("ProjectTeam Component", () => {
     render(
       <ProjectTeam
         timeDuration="2 mesos"
-        contributors={[
-          {
-            id: 12,
-            user_id: 7,
-            name: "Clara",
-            programming_role: "Frontend Developer",
-            avatar_url: null,
-          },
-        ]}
+        contributors={[currentUserContributor]}
       />,
     );
-
     expect(
       screen.getByRole("button", { name: /deixar projecte/i }),
     ).toBeInTheDocument();
+  });
+
+  it("should not render the leave project button when the current user is the project owner", () => {
+    render(
+      <ProjectTeam
+        timeDuration="2 mesos"
+        projectOwnerId={7}
+        contributors={[currentUserContributor]}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /deixar projecte/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
+++ b/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
@@ -13,6 +13,10 @@ vi.mock("../../code-connect/projectCard/ProgressBar", () => ({
   default: () => <div>Barra</div>,
 }));
 
+vi.mock("../../../../utils/getCurrentUserId", () => ({
+  getCurrentUserId: () => 7,
+}));
+
 describe("ProjectTeam Component", () => {
   it("renderitza els títols, la durada i les seccions", () => {
     render(<ProjectTeam timeDuration="2 mesos" />);
@@ -35,5 +39,26 @@ describe("ProjectTeam Component", () => {
     const emptySlots = screen.getAllByRole("button", { name: /\+/i });
     fireEvent.click(emptySlots[0]);
     expect(button).not.toBeDisabled();
+  });
+
+  it("should render the leave project button when the current user is a contributor", () => {
+    render(
+      <ProjectTeam
+        timeDuration="2 mesos"
+        contributors={[
+          {
+            id: 12,
+            user_id: 7,
+            name: "Clara",
+            programming_role: "Frontend Developer",
+            avatar_url: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /deixar projecte/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
+++ b/frontend/src/components/code-connect/projectTeam/__test__/ProjectTeam.test.tsx
@@ -13,8 +13,10 @@ vi.mock("../../code-connect/projectCard/ProgressBar", () => ({
   default: () => <div>Barra</div>,
 }));
 
-vi.mock("../../../../utils/getCurrentUserId", () => ({
-  getCurrentUserId: () => 7,
+vi.mock("../../../../context/UserContext", () => ({
+  useUserContext: () => ({
+    user: { id: 7 },
+  }),
 }));
 
 const currentUserContributor = {

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -73,6 +73,7 @@ const CodeConnectDetails = () => {
                 contributors={codeConnectProject.data.contributors}
                 timeDuration={codeConnectProject.data.time_duration}
                 projectId={codeConnectProject.data.id}
+                projectOwnerId={codeConnectProject.data.user_id}
               />
             </div>
           </div>

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -25,6 +25,8 @@ export interface Project {
 }
 
 export interface ApiProjectContributor {
+   id: number;
+  user_id: number;
   name: string;
   programming_role: ProgrammingRole;
   avatar_url: string | null;

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -25,7 +25,7 @@ export interface Project {
 }
 
 export interface ApiProjectContributor {
-   id: number;
+  id: number;
   user_id: number;
   name: string;
   programming_role: ProgrammingRole;

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -28,7 +28,6 @@ export interface Project {
 
 export interface ApiProjectContributor {
   id: number;
-  user_id: number;
   name: string;
   programming_role: ProgrammingRole;
   avatar_url: string | null;


### PR DESCRIPTION
# Summary

Render the Deixar projecte button only for students who are contributors of the project, excluding the project creator.


# What Changed

- Added contributor id and user_id to ApiProjectContributor.
- Passed the project owner id from CodeConnectDetails to ProjectTeam.
- Used the current logged-in user id to check whether the user is a project contributor.
- Hid the Deixar projecte button when the current user is the project creator.

# Out Of Scope

Calling the delete contributor API.
Removing the contributor from the database.
Updating the team UI after leaving.
Changing TeamRow or ProjectParticipant.
Adding or changing the confirmation modal.

# Test

From the frontend folder:
```
npx vitest run src/components/code-connect/projectTeam/__test__/P
```

>We prioritized this feature first -even though is was added as bonus- because letting the UI know whether the current user is allowed to see the "Deixar projecte" button makes the future delete logic safer and simpler: the button only appears for valid users, and the delete handler will already have the correct contributor record available instead of needing to fetch it in a separate logic.