### PR TITLE
Introduce a minimal global context to manage project join requests ac…

### DIFF
--- a/frontend/src/context/ProjectJoinContext.tsx
+++ b/frontend/src/context/ProjectJoinContext.tsx
@@ -24,7 +24,7 @@ export function ProjectJoinProvider({ children }: { children: ReactNode }) {
       const current = prev[projectId] ?? [];
 
       const exists = current.some(
-        (s) => s.area === slot.area && s.index === slot.index
+        (s) => s.area === slot.area && s.index === slot.index,
       );
 
       if (exists) return prev;

--- a/frontend/src/context/ProjectJoinContext.tsx
+++ b/frontend/src/context/ProjectJoinContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+import type { PendingSlot } from "../types/codeConnectTypes";
+
+export type PendingStatus = "pending";
+
+export interface PendingSlotWithStatus extends PendingSlot {
+  status: PendingStatus;
+}
+
+type State = Record<number, PendingSlotWithStatus[]>;
+
+type ContextType = {
+  requests: State;
+  addRequest: (projectId: number, slot: PendingSlotWithStatus) => void;
+};
+
+const ProjectJoinContext = createContext<ContextType | undefined>(undefined);
+
+export function ProjectJoinProvider({ children }: { children: ReactNode }) {
+  const [requests, setRequests] = useState<State>({});
+
+  const addRequest = (projectId: number, slot: PendingSlotWithStatus) => {
+    setRequests((prev) => {
+      const current = prev[projectId] ?? [];
+
+      const exists = current.some(
+        (s) => s.area === slot.area && s.index === slot.index
+      );
+
+      if (exists) return prev;
+
+      return {
+        ...prev,
+        [projectId]: [...current, slot],
+      };
+    });
+  };
+
+  return (
+    <ProjectJoinContext.Provider value={{ requests, addRequest }}>
+      {children}
+    </ProjectJoinContext.Provider>
+  );
+}
+
+export function useProjectJoinContext() {
+  const ctx = useContext(ProjectJoinContext);
+  if (!ctx) throw new Error("Must be used inside provider");
+  return ctx;
+}

--- a/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
+++ b/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
@@ -1,16 +1,19 @@
 import { renderHook, act } from "@testing-library/react";
+import type { ReactNode, PropsWithChildren } from "react";
 import {
   ProjectJoinProvider,
   useProjectJoinContext,
 } from "../ProjectJoinContext";
 
-function wrapper({ children }: any) {
+function wrapper({ children }: PropsWithChildren) {
   return <ProjectJoinProvider>{children}</ProjectJoinProvider>;
 }
 
 describe("ProjectJoinContext", () => {
   it("adds request correctly", () => {
-    const { result } = renderHook(() => useProjectJoinContext(), { wrapper });
+    const { result } = renderHook(() => useProjectJoinContext(), {
+      wrapper,
+    });
 
     act(() => {
       result.current.addRequest(1, {
@@ -25,7 +28,9 @@ describe("ProjectJoinContext", () => {
   });
 
   it("prevents duplicates", () => {
-    const { result } = renderHook(() => useProjectJoinContext(), { wrapper });
+    const { result } = renderHook(() => useProjectJoinContext(), {
+      wrapper,
+    });
 
     act(() => {
       const slot = {

--- a/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
+++ b/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook, act } from "@testing-library/react";
+import { ProjectJoinProvider, useProjectJoinContext } from "../ProjectJoinContext";
+
+function wrapper({ children }: any) {
+  return <ProjectJoinProvider>{children}</ProjectJoinProvider>;
+}
+
+describe("ProjectJoinContext", () => {
+  it("adds request correctly", () => {
+    const { result } = renderHook(() => useProjectJoinContext(), { wrapper });
+
+    act(() => {
+      result.current.addRequest(1, {
+        area: "frontend",
+        index: 0,
+        role: "Frontend Developer",
+        status: "pending",
+      });
+    });
+
+    expect(result.current.requests[1]).toHaveLength(1);
+  });
+
+  it("prevents duplicates", () => {
+    const { result } = renderHook(() => useProjectJoinContext(), { wrapper });
+
+    act(() => {
+      const slot = {
+        area: "frontend",
+        index: 0,
+        role: "Frontend Developer",
+        status: "pending",
+      };
+
+      result.current.addRequest(1, slot);
+      result.current.addRequest(1, slot);
+    });
+
+    expect(result.current.requests[1]).toHaveLength(1);
+  });
+});

--- a/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
+++ b/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
@@ -1,5 +1,8 @@
 import { renderHook, act } from "@testing-library/react";
-import { ProjectJoinProvider, useProjectJoinContext } from "../ProjectJoinContext";
+import {
+  ProjectJoinProvider,
+  useProjectJoinContext,
+} from "../ProjectJoinContext";
 
 function wrapper({ children }: any) {
   return <ProjectJoinProvider>{children}</ProjectJoinProvider>;

--- a/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
+++ b/frontend/src/context/__tests__/ProjectJoinContext.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import type { ReactNode, PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import {
   ProjectJoinProvider,
   useProjectJoinContext,


### PR DESCRIPTION
This PR introduces a minimal global context to manage project join requests.

It provides a shared state layer that allows synchronization of join actions across different views (Project Card and Project Detail).

## Features
- Add join request per project
- Prevent duplicate slot requests
- Global state accessible via React Context
- Unit tests for core logic

Future PRs will integrate this context into:
- Project Card view
- Project Detail view