### PR TITLE
789 add completed status badge to project details

### DIFF
--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useParams } from "react-router";
 import PendingRequestList from "../components/code-connect/pendingRequests/PendingRequestList";
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
@@ -8,6 +9,7 @@ import { displayLanguageIcon } from "../utils/iconUtils";
 
 const CodeConnectDetails = () => {
   const { projectId } = useParams<{ projectId: string }>();
+  const [isCompleted, setIsCompleted] = useState(false);
 
   const { codeConnectProject, isLoading, errorMessage } = useCodeConnectDetails(
     projectId || null,
@@ -59,6 +61,20 @@ const CodeConnectDetails = () => {
                 </>
               ) : (
                 "Aquesta informació no està disponible a la base de dades."
+              )}
+
+              {!isCompleted ? (
+                <button
+                  type="button"
+                  onClick={() => setIsCompleted(true)}
+                  className="mt-6 text-primary hover:opacity-80 transition-opacity"
+                >
+                  Marcar como completado
+                </button>
+              ) : (
+                <span className="mt-6 font-medium text-gray-500 flex items-center gap-1">
+                  ✓ Completado
+                </span>
               )}
             </div>
 

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -69,11 +69,11 @@ const CodeConnectDetails = () => {
                   onClick={() => setIsCompleted(true)}
                   className="mt-6 text-primary hover:opacity-80 transition-opacity"
                 >
-                  Marcar como completado
+                  Marcar com a complet
                 </button>
               ) : (
                 <span className="mt-6 font-medium text-gray-500 flex items-center gap-1">
-                  ✓ Completado
+                  ✓ Completat
                 </span>
               )}
             </div>

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, type Mock } from "vitest";
 import useCodeConnectDetails from "../../hooks/useCodeConnectDetails";
 import CodeConnectDetails from "../CodeConnectDetails";
@@ -158,7 +159,7 @@ describe("CodeConnectDetails Page", () => {
     const button = screen.getByRole("button", {
       name: /marcar com a complet/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("/Completat/")).toBeTruthy();
   });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -133,4 +133,31 @@ describe("CodeConnectDetails Page", () => {
 
     expect(screen.getByText("Marcar com a complet")).toBeTruthy();
   });
+
+  it("toggles to 'Completat' badge after clicking the button", () => {
+    const mockProjectData = {
+      data: {
+        title: "Projecte Test",
+        description: "Descripció de prova",
+        roadmap: [],
+        contributors: [],
+        time_duration: "2 setmanes",
+        language_frontend: "react",
+        language_backend: "node",
+      },
+    };
+
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: mockProjectData,
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+    
+    const button = screen.getByRole("button", { name: /marcar com a complet/i });
+    button.click();
+    
+    expect(screen.getByText("✓ Completat")).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -131,6 +131,6 @@ describe("CodeConnectDetails Page", () => {
 
     render(<CodeConnectDetails />);
 
-    expect(screen.getByText("Marcar como completado")).toBeTruthy();
+    expect(screen.getByText("Marcar com a complet")).toBeTruthy();
   });
 });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -161,6 +161,6 @@ describe("CodeConnectDetails Page", () => {
     });
     fireEvent.click(button);
 
-    expect(screen.getByText("/Completat/")).toBeTruthy();
+    expect(screen.getByText(/Completat/)).toBeTruthy();
   });
 });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -154,10 +154,12 @@ describe("CodeConnectDetails Page", () => {
     });
 
     render(<CodeConnectDetails />);
-    
-    const button = screen.getByRole("button", { name: /marcar com a complet/i });
+
+    const button = screen.getByRole("button", {
+      name: /marcar com a complet/i,
+    });
     button.click();
-    
+
     expect(screen.getByText("✓ Completat")).toBeTruthy();
   });
 });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -109,4 +109,28 @@ describe("CodeConnectDetails Page", () => {
 
     expect(screen.getByText("Carregant...")).toBeTruthy();
   });
+
+  it("renders the 'Marcar como completado' button", () => {
+    const mockProjectData = {
+      data: {
+        title: "Projecte Test",
+        description: "Descripció de prova",
+        roadmap: [],
+        contributors: [],
+        time_duration: "2 setmanes",
+        language_frontend: "react",
+        language_backend: "node",
+      },
+    };
+
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: mockProjectData,
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+
+    expect(screen.getByText("Marcar como completado")).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -160,6 +160,6 @@ describe("CodeConnectDetails Page", () => {
     });
     button.click();
 
-    expect(screen.getByText("✓ Completat")).toBeTruthy();
+    expect(screen.getByText("/Completat/")).toBeTruthy();
   });
 });

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -40,6 +40,7 @@ export interface ApiProjectData {
   roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
+  status?: "active" | "completed";
 }
 
 export interface ApiContributor {

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -40,7 +40,6 @@ export interface ApiProjectData {
   roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
-  status?: "active" | "completed";
 }
 
 export interface ApiContributor {


### PR DESCRIPTION
This PR adds an interactive "Marcar como completado" button to the CODECONNECT project details page. 
When clicked, the button toggles to a "✓ Completado" badge. 
This is a UI-only implementation for demonstration purposes.

### Screenshots
<img width="697" height="580" alt="Captura de pantalla 2026-06-09 a las 17 16 53" src="https://github.com/user-attachments/assets/f165f722-7e45-4c18-a20c-1c872227b873" />

### After click
<img width="477" height="220" alt="Captura de pantalla 2026-06-09 a las 17 17 00" src="https://github.com/user-attachments/assets/9d51e711-4d10-4216-9d33-5909dc981bb9" />

