### PR TITLE
Fixed column order (date and priority) in ticket page

### DIFF
--- a/frontend/src/components/tickets/TicketList.tsx
+++ b/frontend/src/components/tickets/TicketList.tsx
@@ -36,8 +36,8 @@ const TicketList = ({
           <div role="columnheader">ID</div>
           <div role="columnheader">Descripció</div>
           <div role="columnheader">Estat</div>
-          <div role="columnheader">Data</div>
           <div role="columnheader">Prioritat</div>
+          <div role="columnheader">Data</div>          
           <div role="columnheader">Rol</div>
           <div role="columnheader">Comentari</div>
         </div>

--- a/frontend/src/components/tickets/TicketList.tsx
+++ b/frontend/src/components/tickets/TicketList.tsx
@@ -37,7 +37,7 @@ const TicketList = ({
           <div role="columnheader">Descripció</div>
           <div role="columnheader">Estat</div>
           <div role="columnheader">Prioritat</div>
-          <div role="columnheader">Data</div>          
+          <div role="columnheader">Data</div>
           <div role="columnheader">Rol</div>
           <div role="columnheader">Comentari</div>
         </div>


### PR DESCRIPTION
The order of the column headers on the tickets page has been changed to match the data.

<img width="1434" height="477" alt="image" src="https://github.com/user-attachments/assets/6f1e7d26-47e2-4d98-b1cb-ba07024ee6ef" />
