### PR TITLE
Feature/725 ticketing - wire up comment editing

### DIFF
--- a/frontend/src/components/ticketing/TicketCommentForm.tsx
+++ b/frontend/src/components/ticketing/TicketCommentForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 type Props = {
   onSubmit: (comment: string) => Promise<void>;
@@ -21,6 +21,12 @@ const TicketCommentForm = ({
 }: Props) => {
   const [comment, setComment] = useState("");
   const [editText, setEditText] = useState(initialValue ?? "");
+
+  useEffect(() => {
+    if (initialValue !== undefined) {
+      setEditText(initialValue);
+    }
+  }, [initialValue]);
 
   const isOwner = authorId === currentUserId;
 
@@ -50,7 +56,7 @@ const TicketCommentForm = ({
   return (
     <form className="mt-8" onSubmit={handleSubmit}>
       <h3 className="mb-4 text-sm font-bold text-black underline">Comentari</h3>
-      {initialValue ? (
+      {initialValue !== undefined ? (
         <>
           <textarea
             className={`${textareaClass} ${!isOwner ? "bg-gray-50" : ""}`}

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -8,15 +8,19 @@ import { useTicketingGetAll } from "../hooks/useTicketingGetAll";
 import { useTicketComments } from "../hooks/useTicketComments";
 import TicketList from "../components/tickets/TicketList";
 import type { IntCreateTicket } from "../types/ticketingTypes";
+import { useUserContext } from "../context/UserContext";
 
 const TicketingPage = (): JSX.Element => {
   const { submitTicketing } = useCreateTicketing();
   const { tickets, isLoading, errorMessage, refetch } = useTicketingGetAll();
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+  const { user } = useUserContext();
+  const currentUserId = user?.id;
   const {
     comments,
     error: commentError,
     submitComment,
+    editComment,
   } = useTicketComments(selectedTicketId ?? 0);
 
   const handleCreateTicket = async (
@@ -43,12 +47,17 @@ const TicketingPage = (): JSX.Element => {
         />
         {selectedTicketId !== null && (
           <TicketCommentForm
-            onSubmit={submitComment}
+            onSubmit={
+              comments[0]
+                ? (text) => editComment(comments[0].id, text)
+                : submitComment
+            }
             onClose={() => setSelectedTicketId(null)}
             error={commentError}
             initialValue={comments[0]?.comment}
             authorId={comments[0]?.user_id}
             date={comments[0]?.created_at}
+            currentUserId={currentUserId ?? undefined}
           />
         )}
       </Container>

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -39,6 +39,14 @@ const TicketingPage = (): JSX.Element => {
     }
   };
 
+  const handleCommentSubmit = async (text: string): Promise<void> => {
+    if (comments[0]) {
+      await editComment(comments[0].id, text);
+    } else {
+      await submitComment(text);
+    }
+  };
+
   const toggleStatus = (status: TicketStatus) => {
     setStatusFilter((prev) =>
       prev.includes(status)
@@ -88,11 +96,7 @@ const TicketingPage = (): JSX.Element => {
         />
         {selectedTicketId !== null && (
           <TicketCommentForm
-            onSubmit={
-              comments[0]
-                ? (text) => editComment(comments[0].id, text)
-                : submitComment
-            }
+            onSubmit={handleCommentSubmit}
             onClose={() => setSelectedTicketId(null)}
             error={commentError}
             initialValue={comments[0]?.comment}

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -33,6 +33,10 @@ vi.mock("../../components/ticketing/TicketingCreateForm", () => ({
   ),
 }));
 
+vi.mock("../../context/UserContext", () => ({
+  useUserContext: () => ({ user: { id: 7 } }),
+}));
+
 const mockHook = vi.mocked(useTicketingGetAll);
 const hookReturn = (
   o: Partial<ReturnType<typeof useTicketingGetAll>> = {},


### PR DESCRIPTION
## Summary
Integrates the edit comment hooks and form components into the TicketingPage, fully enabling the edit comment functionality on the UI while fixing an async hydration bug.

## What Changed
Replaced the deprecated getCurrentUserId() in TicketingPage with the global useUserContext() to reliably retrieve the active user's ID.
Wired the editComment hook and the currentUserId down to the TicketCommentForm component.
Added a useEffect inside TicketCommentForm to synchronize the editText state with the initialValue prop. This fixes a hydration bug where the edit textarea would render completely blank if the comment data arrived asynchronously from the backend.

## Out of scope
Adding a visual success notification (e.g., a "Saved!" toast) after editing a comment. This UX enhancement has been proposed for the backlog to maintain this PR's strict scope.

## Test
From the frontend folder (or running Docker):

-Start the development server and make sure you are logged in.
-Navigate to the Ticketing section and click on any existing ticket that has comments.
-If you are the author of a comment, verify that the text area is editable and the "Desar" button is visible.
-Try editing your comment and click "Desar". The comment should update successfully.