### PR TITLE
feat: display accepted projects in my projects section

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -91,6 +91,8 @@ class ListProjectsController extends Controller
                         'name' => $contributor->user->name,
                         'programming_role' => $contributor->programming_role,
                         'avatar_url' => $contributor->user->avatar_url,
+                        'user_id' => $contributor->user_id,
+                        'status' => $contributor->status,
                     ];
                 }),
             ];

--- a/backend/src/tests/Feature/ListProjects/ListProjectsIndexTest.php
+++ b/backend/src/tests/Feature/ListProjects/ListProjectsIndexTest.php
@@ -89,6 +89,8 @@ class ListProjectsIndexTest extends TestCase
                     'name' => $this->contributorOne->user->name,
                     'programming_role' => $this->contributorOne->programming_role,
                     'avatar_url' => $this->contributorOne->user->avatar_url,
+                    'user_id' => $this->contributorOne->user_id,
+                    'status' => $this->contributorOne->status,
                 ]
             ],
         ]);
@@ -135,6 +137,23 @@ class ListProjectsIndexTest extends TestCase
                 'id' => $this->projectOne->user->id,
                 'name'=> $this->projectOne->user->name,
             ]
+        ]);
+    }
+
+    public function test_index_returns_contributor_status_and_user_id(): void
+    {
+        $response = $this->get('/api/codeconnect');
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'contributors' => [
+                [
+                    'name' => $this->contributorOne->user->name,
+                    'programming_role' => $this->contributorOne->programming_role,
+                    'avatar_url' => $this->contributorOne->user->avatar_url,
+                    'user_id' => $this->contributorOne->user_id,
+                    'status' => $this->contributorOne->status,
+                ]
+            ],
         ]);
     }
 

--- a/frontend/src/components/code-connect/projectList/ProjectList.tsx
+++ b/frontend/src/components/code-connect/projectList/ProjectList.tsx
@@ -21,10 +21,14 @@ function ProjectList({
 
   const filteredProjects = useMemo(() => {
     if (showMyProjects && userId) {
-      return projects.filter(project =>
-        [...project.frontend.participants, ...project.backend.participants].some(
-          participant => participant.user_id === userId && participant.status === "accepted"
-        )
+      return projects.filter((project) =>
+        [
+          ...project.frontend.participants,
+          ...project.backend.participants,
+        ].some(
+          (participant) =>
+            participant.user_id === userId && participant.status === "accepted",
+        ),
       );
     }
     if (!filter?.length) return projects;

--- a/frontend/src/components/code-connect/projectList/ProjectList.tsx
+++ b/frontend/src/components/code-connect/projectList/ProjectList.tsx
@@ -8,14 +8,25 @@ import ProjectCard from "../projectCard/ProjectCard";
 function ProjectList({
   onCardClick,
   filter,
+  showMyProjects,
+  userId,
 }: {
   onCardClick?: (id: number) => void;
   filter?: string[] | null;
+  showMyProjects?: boolean;
+  userId?: number | null;
 }) {
   const { projects, isLoading, errorMessage } = useProjects();
   const showLoader = useMinLoading(isLoading);
 
   const filteredProjects = useMemo(() => {
+    if (showMyProjects && userId) {
+      return projects.filter(project =>
+        [...project.frontend.participants, ...project.backend.participants].some(
+          participant => participant.user_id === userId && participant.status === "accepted"
+        )
+      );
+    }
     if (!filter?.length) return projects;
     const normalizedFilter = filter.map((tech) => tech.toLowerCase());
     return projects.filter(
@@ -23,7 +34,7 @@ function ProjectList({
         normalizedFilter.includes(project.frontend.tech.toLowerCase()) ||
         normalizedFilter.includes(project.backend.tech.toLowerCase()),
     );
-  }, [projects, filter]);
+  }, [projects, filter, showMyProjects, userId]);
 
   const hasError = Boolean(errorMessage);
 

--- a/frontend/src/pages/CodeConnectPage.tsx
+++ b/frontend/src/pages/CodeConnectPage.tsx
@@ -46,8 +46,11 @@ const CodeConnectPage = () => {
           </div>
         </div>
         <p className="text-black py-5">Vull practicar com a developer de:</p>
-        <CodeConnectFiltersComponent selected={filter} onChange={handleFilterChange} />
-        <ProjectList 
+        <CodeConnectFiltersComponent
+          selected={filter}
+          onChange={handleFilterChange}
+        />
+        <ProjectList
           filter={filter}
           showMyProjects={showMyProjects}
           userId={user?.id}

--- a/frontend/src/pages/CodeConnectPage.tsx
+++ b/frontend/src/pages/CodeConnectPage.tsx
@@ -5,11 +5,21 @@ import CodeConnectFiltersComponent from "../components/code-connect/CodeConnectF
 import ProjectList from "../components/code-connect/projectList/ProjectList";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
+import { useUserContext } from "../context/UserContext";
 
 const CodeConnectPage = () => {
   const navigate = useNavigate();
   const [filter, setFilter] = useState<string[]>([]);
   const [showMyProjects, setShowMyProjects] = useState<boolean>(false);
+  const { user } = useUserContext();
+  const handleFilterChange = (selected: string[]) => {
+    setFilter(selected);
+    setShowMyProjects(false);
+  };
+  const handleMyProjects = () => {
+    setShowMyProjects(!showMyProjects);
+    setFilter([]);
+  };
 
   return (
     <>
@@ -23,7 +33,7 @@ const CodeConnectPage = () => {
             <ButtonComponent
               variant="custom"
               className="text-primary font-[600] text-[14px] h-[41px] min-w-[152px] cursor-pointer hover:opacity-90"
-              onClick={() => setShowMyProjects(!showMyProjects)}
+              onClick={handleMyProjects}
             >
               Els meus projectes
             </ButtonComponent>
@@ -36,8 +46,12 @@ const CodeConnectPage = () => {
           </div>
         </div>
         <p className="text-black py-5">Vull practicar com a developer de:</p>
-        <CodeConnectFiltersComponent selected={filter} onChange={setFilter} />
-        <ProjectList filter={filter} />
+        <CodeConnectFiltersComponent selected={filter} onChange={handleFilterChange} />
+        <ProjectList 
+          filter={filter}
+          showMyProjects={showMyProjects}
+          userId={user?.id}
+        />
       </Container>
     </>
   );

--- a/frontend/src/pages/__test__/CodeConnectPage.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectPage.test.tsx
@@ -68,4 +68,21 @@ describe("CodeConnectPage", () => {
       screen.getByRole("button", { name: /Els meus projectes/i }),
     ).toBeInTheDocument();
   });
+
+  it("toggles my projects filter when clicking My projects button", () => {
+    render(
+      <MemoryRouter initialEntries={["/codeconnect"]}>
+        <UserProvider>
+          <Routes>
+            <Route path="/codeconnect" element={<CodeConnectPage />} />
+          </Routes>
+        </UserProvider>
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByRole("button", { name: /Els meus projectes/i });
+    fireEvent.click(button);
+
+    expect(button).toBeInTheDocument();
+  });
 });

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -5,6 +5,8 @@ export type ProgrammingRole = "Frontend Developer" | "Backend Developer";
 export interface ProjectParticipant {
   name: string;
   avatar: string;
+  user_id: number;
+  status: "pending" | "accepted" | "rejected";
 }
 
 export interface ProjectSideInfo {
@@ -28,6 +30,8 @@ export interface ApiProjectContributor {
   name: string;
   programming_role: ProgrammingRole;
   avatar_url: string | null;
+  user_id: number;
+  status: "pending" | "accepted" | "rejected";
 }
 
 export interface ApiProjectData {


### PR DESCRIPTION
**Description:**

Implements the filtering logic for the "Els meus projectes" button in the CodeConnect dashboard. When clicked, it shows only the projects where the authenticated user has an accepted contributor status.

**Changes:**

- Added user_id and status fields to contributors in ListProjectsController index() response
- Updated ApiProjectContributor and ProjectParticipant types to include user_id and status
- Added showMyProjects and userId props to ProjectList with filtering logic
- Connected useUserContext to CodeConnectPage to pass the authenticated user's id
- Updated existing backend test to include new contributor fields
- Added backend test to verify user_id and status are returned in contributors