### PR TITLE
feat: connect trigger button to weekly transition API

### DIFF
--- a/frontend/src/pages/LeaguesPage.tsx
+++ b/frontend/src/pages/LeaguesPage.tsx
@@ -9,12 +9,15 @@ import rotateIcon from "../assets/rotate.svg";
 import UiButton from "../components/ui/shared-ui/UiButton";
 import GenericModal from "../components/ui/Modal/GenericModal";
 import PointsHistoryTable from "../components/leagues-ranking/PointsHistoryTable/PointsHistoryTable";
+import { useTriggerWeeklyTransition } from "../hooks/useTriggerWeeklyTransition";
+import { triggerWeeklyTransition } from "../api/endPointLeagues";
 
 const LeaguesPage = () => {
   const [view, setView] = useState<LeagueView>("weekly");
   const { user } = useUser();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isTriggerModalOpen, setIsTriggerModalOpen] = useState(false);
+  const { trigger } = useTriggerWeeklyTransition({triggerWeeklyTransition});
 
   return (
     <div className="px-6 md:px-10 xl:px-20 2xl:px-6 flex flex-col gap-10">
@@ -62,7 +65,7 @@ const LeaguesPage = () => {
         title="Actualitzar lligues"
         showPrimaryButton
         primaryButtonText="Confirmar"
-        primaryButtonAction={() => setIsTriggerModalOpen(false)}
+        primaryButtonAction={async () => { await trigger(); setIsTriggerModalOpen(false); }}
         showSecondaryButton
         secondaryButtonText="Cancel·lar"
         secondaryButtonAction={() => setIsTriggerModalOpen(false)}

--- a/frontend/src/pages/LeaguesPage.tsx
+++ b/frontend/src/pages/LeaguesPage.tsx
@@ -17,7 +17,7 @@ const LeaguesPage = () => {
   const { user } = useUser();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isTriggerModalOpen, setIsTriggerModalOpen] = useState(false);
-  const { trigger } = useTriggerWeeklyTransition({triggerWeeklyTransition});
+  const { trigger } = useTriggerWeeklyTransition({ triggerWeeklyTransition });
 
   return (
     <div className="px-6 md:px-10 xl:px-20 2xl:px-6 flex flex-col gap-10">
@@ -65,7 +65,10 @@ const LeaguesPage = () => {
         title="Actualitzar lligues"
         showPrimaryButton
         primaryButtonText="Confirmar"
-        primaryButtonAction={async () => { await trigger(); setIsTriggerModalOpen(false); }}
+        primaryButtonAction={async () => {
+          await trigger();
+          setIsTriggerModalOpen(false);
+        }}
         showSecondaryButton
         secondaryButtonText="Cancel·lar"
         secondaryButtonAction={() => setIsTriggerModalOpen(false)}


### PR DESCRIPTION
Summary
 
Connects the trigger button confirm action to the useTriggerWeeklyTransition hook, completing the functionality introduced in #772.

- Imports useTriggerWeeklyTransition hook and triggerWeeklyTransition API function
- Calls trigger() on confirm, then closes the modal

Test plan

- [x] Login as mentor/admin
- [x] Open leagues page
- [x] Click trigger button → modal opens
- [x] Click Confirmar → points_weekly resets to 0 in DB
- [x] Click Cancel·lar → modal closes without changes

Test coverage

The useTriggerWeeklyTransition hook is already covered in hooks/__tests__/useTriggerWeeklyTransition.test.ts