### PR TITLE
feat: add league transition tracking and notification state fields to liga model + tests

### DIFF
--- a/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
+++ b/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Liga;
 use Illuminate\Console\Command;
 
 class ProcessLeaguePromotions extends Command
@@ -15,6 +16,22 @@ class ProcessLeaguePromotions extends Command
     {
         $this->info('League promotion process started.');
 
+        // Promotion/demotion logic is implemented in issue 831.
+        // For every user whose league changes, call:
+        //   $this->trackLeagueChange($liga, $newLeagueId);
+
         return self::SUCCESS;
+    }
+
+    /**
+     * Saves the user's current league as previous_league_id, assigns the new league,
+     * and resets the notification flag so the modal appears on next login.
+     */
+    public function trackLeagueChange(Liga $liga, int $newLeagueId): void
+    {
+        $liga->previous_league_id    = $liga->league_id->value;
+        $liga->league_id             = $newLeagueId;
+        $liga->notification_dismissed = false;
+        $liga->save();
     }
 }

--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -21,18 +21,23 @@ class Liga extends Model
         'status',
         'language',
         'league_id',
+        'previous_league_id',
+        'notification_dismissed',
     ];
 
     protected $attributes = [
-        'points_weekly'=> 0,
-        'status'=> 'Junior Coder',
+        'points_weekly'        => 0,
+        'status'               => 'Junior Coder',
+        'notification_dismissed' => false,
     ];
 
     protected $casts = [
-        'points'=> 'integer',
-        'points_weekly'=> 'integer',
-        'league_id'=> LeagueTypeEnum::class,
-        'status'=> LigaStatusEnum::class, 
+        'points'                 => 'integer',
+        'points_weekly'          => 'integer',
+        'league_id'              => LeagueTypeEnum::class,
+        'status'                 => LigaStatusEnum::class,
+        'previous_league_id'     => 'integer',
+        'notification_dismissed' => 'boolean',
     ];
 
     public function user(): BelongsTo

--- a/backend/src/database/migrations/2026_06_19_091500_add_notification_fields_to_ligas_table.php
+++ b/backend/src/database/migrations/2026_06_19_091500_add_notification_fields_to_ligas_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ligas', function (Blueprint $table): void {
+            $table->unsignedBigInteger('previous_league_id')->nullable()->after('league_id');
+            $table->boolean('notification_dismissed')->default(false)->after('previous_league_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ligas', function (Blueprint $table): void {
+            $table->dropColumn(['previous_league_id', 'notification_dismissed']);
+        });
+    }
+};

--- a/backend/src/tests/Feature/LigaTests/LigaNotificationFieldsTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaNotificationFieldsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\LigaTests;
+
+use App\Console\Commands\ProcessLeaguePromotions;
+use App\Enums\LeagueTypeEnum;
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class LigaNotificationFieldsTest extends TestCase
+{
+    public function test_ligas_table_has_notification_tracking_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumn('ligas', 'previous_league_id'));
+        $this->assertTrue(Schema::hasColumn('ligas', 'notification_dismissed'));
+    }
+
+    public function test_previous_league_id_defaults_to_null(): void
+    {
+        $user = User::factory()->create();
+        $liga = Liga::create(['user_id' => $user->id, 'points' => 0]);
+
+        $this->assertNull($liga->previous_league_id);
+    }
+
+    public function test_notification_dismissed_defaults_to_false(): void
+    {
+        $user = User::factory()->create();
+        $liga = Liga::create(['user_id' => $user->id, 'points' => 0]);
+
+        $this->assertFalse($liga->notification_dismissed);
+    }
+
+    public function test_track_league_change_saves_previous_league_and_resets_flag(): void
+    {
+        $user = User::factory()->create();
+        $liga = Liga::create([
+            'user_id'                => $user->id,
+            'points'                 => 10,
+            'league_id'              => LeagueTypeEnum::Bronze,
+            'notification_dismissed' => true,
+        ]);
+
+        $command = new ProcessLeaguePromotions();
+        $command->trackLeagueChange($liga, LeagueTypeEnum::Silver->value);
+
+        $liga->refresh();
+
+        $this->assertEquals(LeagueTypeEnum::Bronze->value, $liga->previous_league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver, $liga->league_id);
+        $this->assertFalse($liga->notification_dismissed);
+    }
+
+    public function test_track_league_change_resets_flag_even_if_already_dismissed(): void
+    {
+        $user = User::factory()->create();
+        $liga = Liga::create([
+            'user_id'                => $user->id,
+            'points'                 => 20,
+            'league_id'              => LeagueTypeEnum::Silver,
+            'notification_dismissed' => true,
+        ]);
+
+        $command = new ProcessLeaguePromotions();
+        $command->trackLeagueChange($liga, LeagueTypeEnum::Gold->value);
+
+        $liga->refresh();
+
+        $this->assertFalse($liga->notification_dismissed);
+        $this->assertEquals(LeagueTypeEnum::Silver->value, $liga->previous_league_id);
+    }
+}


### PR DESCRIPTION
## Context

After a weekly league transition, the system had no way to know whether a user's league had changed, by how much, or in which direction. This PR adds the database foundation needed to power the "promotion/demotion notification modal" feature.

## What this PR does

Adds two new columns to the ligas table:

- previous_league_id (nullable integer) — stores the user's league before the weekly transition runs. Defaults to null, meaning no transition has occurred yet for that user.
- notification_dismissed (boolean, default false) — tracks whether the user has already seen the notification modal for the current league change. Reset to false every time the user's league changes, so recurring promotions/demotions always trigger a fresh modal.

Adds a trackLeagueChange() method to ProcessLeaguePromotions that encapsulates the flag-setting logic:
- Saves current league_id into previous_league_id
- Assigns the new league_id
- Resets notification_dismissed to false

⚠️ Integration note for issue #831 (Lauren)
ProcessLeaguePromotions::handle() is still a stub — the actual promotion/demotion loop is implemented in issue #831 (Tier Transition). Once that PR is merged, the integration point is:

```bash
// Inside the promotion/demotion loop in handle():
$this->trackLeagueChange($liga, $newLeagueId);
```
trackLeagueChange() is already tested and ready to be called. No changes to the method itself should be needed.

Run the tests:

```bash
docker compose exec backend php artisan test src/tests/Feature/LigaTests/LigaNotificationFieldsTest.php
Expected output: 5 passed, 9 assertions.
```

Run the migration manually:

```bash
docker compose exec backend php artisan migrate
```
Then verify the new columns exist:

```bash
docker compose exec backend php artisan tinker
>>> \Illuminate\Support\Facades\Schema::getColumnListing('ligas');
```
You should see previous_league_id and notification_dismissed in the list.

Verify defaults on a new entry:
```bash
>>> $user = \App\Models\User::first();
>>> $liga = \App\Models\Liga::where('user_id', $user->id)->first();
>>> $liga->previous_league_id;  // null
>>> $liga->notification_dismissed; // false
```