### PR TITLE
feat: add notification tracking fields to Ligas table and update model attributes

### DIFF
--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -21,18 +21,23 @@ class Liga extends Model
         'status',
         'language',
         'league_id',
+        'previous_league_id',
+        'notification_dismissed',
     ];
 
     protected $attributes = [
-        'points_weekly'=> 0,
-        'status'=> 'Junior Coder',
+        'points_weekly'          => 0,
+        'status'                 => 'Junior Coder',
+        'notification_dismissed' => false,
     ];
 
     protected $casts = [
-        'points'=> 'integer',
-        'points_weekly'=> 'integer',
-        'league_id'=> LeagueTypeEnum::class,
-        'status'=> LigaStatusEnum::class, 
+        'points'                 => 'integer',
+        'points_weekly'          => 'integer',
+        'league_id'              => LeagueTypeEnum::class,
+        'status'                 => LigaStatusEnum::class,
+        'previous_league_id'     => 'integer',
+        'notification_dismissed' => 'boolean',
     ];
 
     public function user(): BelongsTo

--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -36,7 +36,7 @@ class Liga extends Model
         'points_weekly'          => 'integer',
         'league_id'              => LeagueTypeEnum::class,
         'status'                 => LigaStatusEnum::class,
-        'previous_league_id'     => 'integer',
+        'previous_league_id'     => LeagueTypeEnum::class,
         'notification_dismissed' => 'boolean',
     ];
 

--- a/backend/src/database/factories/LigaFactory.php
+++ b/backend/src/database/factories/LigaFactory.php
@@ -18,12 +18,14 @@ class LigaFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id'       => User::factory(),
-            'points'        => fake()->numberBetween(0, 100),
-            'points_weekly' => fake()->numberBetween(0, 100),
-            'language'      => fake()->randomElement(LanguageEnum::values()),
-            'status'        => fake()->randomElement(LigaStatusEnum::values()),
-            'league_id'     => fake()->randomElement(LeagueTypeEnum::values()),
+            'user_id'                => User::factory(),
+            'points'                 => fake()->numberBetween(0, 100),
+            'points_weekly'          => fake()->numberBetween(0, 100),
+            'language'               => fake()->randomElement(LanguageEnum::values()),
+            'status'                 => fake()->randomElement(LigaStatusEnum::values()),
+            'league_id'              => fake()->randomElement(LeagueTypeEnum::values()),
+            'previous_league_id'     => null,
+            'notification_dismissed' => false,
         ];
     }
 }

--- a/backend/src/database/migrations/2026_06_19_091500_add_notification_fields_to_ligas_table.php
+++ b/backend/src/database/migrations/2026_06_19_091500_add_notification_fields_to_ligas_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ligas', function (Blueprint $table): void {
+            $table->unsignedBigInteger('previous_league_id')->nullable()->after('league_id');
+            $table->boolean('notification_dismissed')->default(false)->after('previous_league_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ligas', function (Blueprint $table): void {
+            $table->dropColumn(['previous_league_id', 'notification_dismissed']);
+        });
+    }
+};

--- a/backend/src/tests/Feature/LigaTests/LigaNotificationFieldsTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaNotificationFieldsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\LigaTests;
+
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class LigaNotificationFieldsTest extends TestCase
+{
+    public function test_ligas_table_has_notification_tracking_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumn('ligas', 'previous_league_id'));
+        $this->assertTrue(Schema::hasColumn('ligas', 'notification_dismissed'));
+    }
+
+    public function test_notification_fields_have_correct_defaults(): void
+    {
+        $user = User::factory()->create();
+        $liga = Liga::create(['user_id' => $user->id, 'points' => 0]);
+
+        $this->assertNull($liga->previous_league_id);
+        $this->assertFalse($liga->notification_dismissed);
+    }
+}


### PR DESCRIPTION
## What this PR does
Adds two new columns to the `ligas` table to support league-change notification tracking:
- `previous_league_id` (unsignedBigInteger, nullable): stores the user's previous league before a promotion/demotion.
- `notification_dismissed` (boolean, default false): tracks whether the user has acknowledged the notification.
Also updates the `Liga` model to reflect these fields in `$fillable`, `$attributes` and `$casts`.

## How to test
Run inside the container:
```bash
docker compose exec backend php artisan test src/tests/Feature/LigaTests/