### PR TITLE
Added new fields to list_projects table

### DIFF
--- a/backend/src/app/Http/Requests/ListProjectRequest.php
+++ b/backend/src/app/Http/Requests/ListProjectRequest.php
@@ -35,7 +35,8 @@ class ListProjectRequest extends FormRequest
             'language_backend' => 'required|string|max:255',
             'language_frontend' => 'required|string|max:255',
             'roadmap' => 'nullable|array',
-
+            'github_url' => ['nullable', 'url'],
+            'youtube_url' => ['nullable', 'url'],
             'programming_role' => [
                 $this->isMethod('post') ? 'required' : 'nullable',
                 'string',
@@ -61,6 +62,8 @@ class ListProjectRequest extends FormRequest
             'language_frontend.required' => "The frontend language field is required.",
             'programming_role.required' => 'The programming role field is required.',
             'programming_role.in' => 'The programming role must be one of: Frontend Developer, Backend Developer, Fullstack Developer, Other.',
+            'github_url.url' => 'The GitHub URL must be a valid URL.',
+            'youtube_url.url' => 'The YouTube URL must be a valid URL.',
         ];
     }
 }

--- a/backend/src/app/Models/ListProjects.php
+++ b/backend/src/app/Models/ListProjects.php
@@ -30,8 +30,9 @@ class ListProjects extends Model
         'language_backend',
         'language_frontend',
         'description',
-        'roadmap'
-    
+        'roadmap',
+        'github_url',
+        'youtube_url',
     ];
 
     public function contributorListProject()

--- a/backend/src/database/factories/ListProjectsFactory.php
+++ b/backend/src/database/factories/ListProjectsFactory.php
@@ -33,6 +33,8 @@ class ListProjectsFactory extends Factory
             'time_duration' => $this->faker->word(),
             'language_backend' => $this->faker->randomElement($languages),
             'language_frontend' => $this->faker->randomElement($languages),
+            'github_url' => $this->faker->optional()->url(),
+            'youtube_url' => $this->faker->optional()->url(),
             'roadmap'=> $this->faker->optional()->passthrough([
                 ['task' => $this->faker->sentence(3), 'done' => $this->faker->boolean()],
                 ['task' => $this->faker->sentence(3), 'done' => $this->faker->boolean()],

--- a/backend/src/database/migrations/2026_06_19_100000_add_URLs_to_list_projects_table.php
+++ b/backend/src/database/migrations/2026_06_19_100000_add_URLs_to_list_projects_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('list_projects', function (Blueprint $table) {
+            
+            $table->string('github_url')->nullable()->after('roadmap');
+            $table->string('youtube_url')->nullable()->after('github_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('list_projects', function (Blueprint $table) {
+
+            $table->dropColumn(['github_url', 'youtube_url']);
+        });
+    }
+};

--- a/backend/src/database/seeders/ListProjectsSeeder.php
+++ b/backend/src/database/seeders/ListProjectsSeeder.php
@@ -29,6 +29,8 @@ class ListProjectsSeeder extends Seeder
                 'time_duration' => '1 month',
                 'language_backend' => LanguageEnum::PHP->value,
                 'language_frontend' => LanguageEnum::JavaScript->value,
+                'github_url' => 'https://github.com/example/project-alpha',
+                'youtube_url' => 'https://www.youtube.com/watch?v=example',
                 'roadmap' => [
                     ['task' => 'Setup structure', 'done' => true],
                     ['task' => 'Implement authentication', 'done' => false],
@@ -47,6 +49,8 @@ class ListProjectsSeeder extends Seeder
                 'time_duration' => '2 months',
                 'language_backend' => LanguageEnum::Python->value,
                 'language_frontend' => LanguageEnum::React->value,
+                'github_url' => 'https://github.com/example/project-beta',
+                'youtube_url' => 'https://www.youtube.com/watch?v=example',
                 'roadmap' => [
                     ['task' => 'Design database', 'done' => true],
                     ['task' => 'Create ui components', 'done' => false],
@@ -65,10 +69,13 @@ class ListProjectsSeeder extends Seeder
                 'time_duration' => '3 weeks',
                 'language_backend' => LanguageEnum::Java->value,
                 'language_frontend' => LanguageEnum::TypeScript->value,
+                'github_url' => 'https://github.com/example/project-gamma',
+                'youtube_url' => 'https://www.youtube.com/watch?v=example',
                 'roadmap' => [
                     ['task' => 'Setup CI/CD pipeline', 'done' => true],
                     ['task' => 'Implement user roles', 'done' => false],
                 ],
+                
             ]
         );
     }


### PR DESCRIPTION
### **Description**
This PR has been designed to create and save the data for the new fields (github-url and youtube_url) that will be used when a project is finished.

### **Context:**
Currently, there is no difference between an ongoing project and a completed one. With this pull request, we want to ensure that upon project completion, the URLs for both the project repository and a YouTube demo are included, which will be displayed when the project is closed.

### **Changes included:**
Added new URL fields (github_url and youtube_url) to list_projects table
Modified the ListProyectRequests for the two new fields
Updated the factory (ListProjectsFactory.php) and the seeder (ListProjectsSeeder.php) files for theses new fields too
Updated the fillable list with the 2 new fields