### PR TITLE
Feat/add suggestions button

### DIFF
--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -93,8 +93,8 @@ const TicketingPage = (): JSX.Element => {
           className="w-full flex justify-start"
           variant="discreet"
           onClick={() => {}}
-          >
-          Veure Suggeriments
+        >
+          Veure suggeriments
         </ButtonComponent>
         <TicketList
           tickets={filteredTickets}

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -10,6 +10,7 @@ import TicketList from "../components/tickets/TicketList";
 import { useUserContext } from "../context/UserContext";
 import { STATUS_LABELS } from "../components/tickets/ticketConstants";
 import type { IntCreateTicket, TicketStatus } from "../types/ticketingTypes";
+import ButtonComponent from "../components/atoms/ButtonComponent";
 
 const DEFAULT_STATUSES: TicketStatus[] = ["pending", "in_progress"];
 
@@ -88,6 +89,13 @@ const TicketingPage = (): JSX.Element => {
             </button>
           )}
         </div>
+        <ButtonComponent
+          className="w-full flex justify-start"
+          variant="discreet"
+          onClick={() => {}}
+          >
+          Veure Suggeriments
+        </ButtonComponent>
         <TicketList
           tickets={filteredTickets}
           isLoading={isLoading}

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -113,11 +113,4 @@ describe("TicketingPage", () => {
     const button = screen.getByRole("button", { name: "Veure suggeriments" });
     expect(button).toBeInTheDocument();
   });
-
-  it("'suggeriments' button is clickable", () => {
-    render(<TicketingPage />);
-    const button = screen.getByRole("button", { name: "Veure suggeriments" });
-    fireEvent.click(button);
-    expect(button).toBeInTheDocument();
-  });
 });

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -107,4 +107,17 @@ describe("TicketingPage", () => {
     fireEvent.click(blockedCheckbox);
     expect(screen.getAllByTestId("ticket-list-item")).toHaveLength(3);
   });
+
+  it("it renders 'suggeriments' button", () => {
+    render(<TicketingPage />);
+    const button = screen.getByRole("button", { name: "Veure suggeriments" });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("'suggeriments' button is clickable", () => {
+    render(<TicketingPage />);
+    const button = screen.getByRole("button", { name: "Veure suggeriments" });
+    fireEvent.click(button);
+    expect(button).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Add "Veure suggeriments" Button on ticketing

_Add a "veure suggeritments" button on on ticketing page that will allow students to vote for their favorites in the furture._

### what's changed

Added  "veure sugeeritments" button on UI

### out of scope 
- rendering only on student view
- filtering suggeriments

### test 
```npx vitest run src/pages/__test__/TicketingPage.test.tsx      ```      