### PR TITLE
feat: implement promotion and demotion logic

### DIFF
--- a/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
+++ b/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
@@ -4,16 +4,53 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Liga;
 use Illuminate\Console\Command;
 
 class ProcessLeaguePromotions extends Command
 {
     protected $signature = 'liga:process-promotions';
+
     protected $description = 'Process weekly league promotions and demotions';
 
     public function handle(): int
     {
-        $this->info('League promotion process started.');
+        $minUsersToProcess = 4;
+        $allLeagues = Liga::all();
+        $bronzeLeagues = $allLeagues->where('league_id', 1);
+        $silverLeagues = $allLeagues->where('league_id', 2);
+        $goldLeagues = $allLeagues->where('league_id', 3);
+
+        $bronzeToSilver = $bronzeLeagues->count() >= $minUsersToProcess
+            ? $bronzeLeagues->sortByDesc('points_weekly')->take(3)->pluck('id')
+            : collect();
+
+        $silverToGold = $silverLeagues->count() >= $minUsersToProcess
+            ? $silverLeagues->sortByDesc('points_weekly')->take(3)->pluck('id')
+            : collect();
+
+        $goldToSilver = $goldLeagues->count() >= $minUsersToProcess
+            ? $goldLeagues->sortBy('points_weekly')->take(3)->pluck('id')
+            : collect();
+
+        $silverToBronze = $silverLeagues->count() >= $minUsersToProcess
+            ? $silverLeagues->whereNotIn('id', $silverToGold)->sortBy('points_weekly')->take(3)->pluck('id')
+            : collect();
+
+        \Illuminate\Support\Facades\DB::transaction(function () use ($bronzeToSilver, $silverToGold, $goldToSilver, $silverToBronze) {
+            if ($bronzeToSilver->isNotEmpty()) {
+                Liga::whereIn('id', $bronzeToSilver)->update(['league_id' => 2]);
+            }
+            if ($silverToGold->isNotEmpty()) {
+                Liga::whereIn('id', $silverToGold)->update(['league_id' => 3]);
+            }
+            if ($goldToSilver->isNotEmpty()) {
+                Liga::whereIn('id', $goldToSilver)->update(['league_id' => 2]);
+            }
+            if ($silverToBronze->isNotEmpty()) {
+                Liga::whereIn('id', $silverToBronze)->update(['league_id' => 1]);
+            }
+        });
 
         return self::SUCCESS;
     }

--- a/backend/src/routes/console.php
+++ b/backend/src/routes/console.php
@@ -13,4 +13,8 @@ Artisan::command('liga:reset-weekly', function () {
     $this->info('liga:reset-weekly');
 })->purpose('Reset weekly points for all liga entries');
 
+Artisan::command('liga:process-promotions', function () {
+    app(\App\Console\Commands\ProcessLeaguePromotions::class)->handle();
+})->purpose('Process weekly league promotions and demotions');
+
 Schedule::command('liga:reset-weekly')->weeklyOn(0, '00:00');

--- a/backend/src/tests/Feature/LigaTests/ProcessLeaguePromotionsTest.php
+++ b/backend/src/tests/Feature/LigaTests/ProcessLeaguePromotionsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Liga;
+
+use App\Enums\LeagueTypeEnum;
+use App\Models\Liga;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProcessLeaguePromotionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_top_3_in_bronze_are_promoted_to_silver(): void
+    {
+        $users = User::factory(4)->create();
+        Liga::create(['user_id' => $users[0]->id, 'points_weekly' => 30, 'league_id' => LeagueTypeEnum::Bronze]);
+        Liga::create(['user_id' => $users[1]->id, 'points_weekly' => 20, 'league_id' => LeagueTypeEnum::Bronze]);
+        Liga::create(['user_id' => $users[2]->id, 'points_weekly' => 10, 'league_id' => LeagueTypeEnum::Bronze]);
+        Liga::create(['user_id' => $users[3]->id, 'points_weekly' => 5,  'league_id' => LeagueTypeEnum::Bronze]);
+
+        $this->artisan('liga:process-promotions')->assertExitCode(0);
+
+        $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[0]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[1]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[2]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Bronze, Liga::where('user_id', $users[3]->id)->first()->league_id);
+    }
+
+    public function test_bottom_3_in_gold_are_demoted_to_silver(): void
+    {
+        $users = User::factory(4)->create();
+        Liga::create(['user_id' => $users[0]->id, 'points_weekly' => 30, 'league_id' => LeagueTypeEnum::Gold]);
+        Liga::create(['user_id' => $users[1]->id, 'points_weekly' => 20, 'league_id' => LeagueTypeEnum::Gold]);
+        Liga::create(['user_id' => $users[2]->id, 'points_weekly' => 10, 'league_id' => LeagueTypeEnum::Gold]);
+        Liga::create(['user_id' => $users[3]->id, 'points_weekly' => 5,  'league_id' => LeagueTypeEnum::Gold]);
+
+        $this->artisan('liga:process-promotions')->assertExitCode(0);
+
+        $this->assertEquals(LeagueTypeEnum::Gold, Liga::where('user_id', $users[0]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[1]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[2]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[3]->id)->first()->league_id);
+    }
+
+    public function test_global_points_are_not_affected(): void
+    {
+        $user = User::factory()->create();
+        Liga::create(['user_id' => $user->id, 'points' => 100, 'points_weekly' => 50, 'league_id' => LeagueTypeEnum::Bronze]);
+
+        $this->artisan('liga:process-promotions')->assertExitCode(0);
+
+        $this->assertEquals(100, Liga::where('user_id', $user->id)->first()->points);
+    }
+}


### PR DESCRIPTION
DESCRIPTION

Promote the top 3 students and demote the bottom 3 students between league tiers, so that the league reflects weekly performance.

OUT OF SCOPE

- Scheduling or triggering the process
- Resetting weekly points
- Frontend changes
- 
ACCEPTANCE CRITERIA

- Top 3 students in Bronze are promoted to Silver
- Top 3 students in Silver are promoted to Gold
- Bottom 3 students in Silver are demoted to Bronze
- Bottom 3 students in Gold are demoted to Silver
- Students in Gold are never promoted further
- Students in Bronze are never demoted further
- Historical cumulative points (points) are not affected
- Logic is implemented inside ProcessLeaguePromotions command
- Test