### PR TITLE
Add new field in the data base to be able to mark as complete projects in future api call

### DIFF
--- a/backend/src/app/Enums/ProjectStatusEnum.php
+++ b/backend/src/app/Enums/ProjectStatusEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ProjectStatusEnum: string
+{
+    case IN_PROGRESS = 'in_progress';
+    case COMPLETED = 'completed';
+    
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/backend/src/app/Http/Requests/ListProjectRequest.php
+++ b/backend/src/app/Http/Requests/ListProjectRequest.php
@@ -5,6 +5,8 @@ declare (strict_types= 1);
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Enums\ProjectStatusEnum;
 
 class ListProjectRequest extends FormRequest
 {
@@ -35,12 +37,12 @@ class ListProjectRequest extends FormRequest
             'language_backend' => 'required|string|max:255',
             'language_frontend' => 'required|string|max:255',
             'roadmap' => 'nullable|array',
-
             'programming_role' => [
                 $this->isMethod('post') ? 'required' : 'nullable',
                 'string',
                 'in:Frontend Developer,Backend Developer,Fullstack Developer,Other',
             ],
+            'status' => ['nullable', Rule::enum(ProjectStatusEnum::class)]
         ];
     }
 
@@ -61,6 +63,7 @@ class ListProjectRequest extends FormRequest
             'language_frontend.required' => "The frontend language field is required.",
             'programming_role.required' => 'The programming role field is required.',
             'programming_role.in' => 'The programming role must be one of: Frontend Developer, Backend Developer, Fullstack Developer, Other.',
+            'status.enum' => 'The status must be either in_progress or completed.',
         ];
     }
 }

--- a/backend/src/app/Models/ListProjects.php
+++ b/backend/src/app/Models/ListProjects.php
@@ -8,6 +8,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Models\ForumQuestion;
+use App\Enums\ProjectStatusEnum;
 
 class ListProjects extends Model
 {
@@ -17,6 +18,7 @@ class ListProjects extends Model
         'roadmap' => 'array',
         'start_date' => 'date',
         'end_date' => 'date',
+        'status' => ProjectStatusEnum::class,
     ];
     protected $fillable = [
         'user_id',
@@ -30,8 +32,8 @@ class ListProjects extends Model
         'language_backend',
         'language_frontend',
         'description',
-        'roadmap'
-    
+        'roadmap',
+        'status',
     ];
 
     public function contributorListProject()

--- a/backend/src/database/factories/ListProjectsFactory.php
+++ b/backend/src/database/factories/ListProjectsFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Enums\LanguageEnum;
+use App\Enums\ProjectStatusEnum;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -36,7 +37,8 @@ class ListProjectsFactory extends Factory
             'roadmap'=> $this->faker->optional()->passthrough([
                 ['task' => $this->faker->sentence(3), 'done' => $this->faker->boolean()],
                 ['task' => $this->faker->sentence(3), 'done' => $this->faker->boolean()],
-            ])
+            ]),
+            'status' => $this->faker->randomElement(ProjectStatusEnum::values()),
         ];
     }
 }

--- a/backend/src/database/migrations/2026_06_22_100000_add_status_to_list_projects_table.php
+++ b/backend/src/database/migrations/2026_06_22_100000_add_status_to_list_projects_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ProjectStatusEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('list_projects', function (Blueprint $table): void {
+            $table->enum('status', ProjectStatusEnum::values())
+                  ->default(ProjectStatusEnum::IN_PROGRESS->value)
+                  ->after('language_frontend');
+        });
+    }
+    public function down(): void
+    {
+        Schema::table('list_projects', function (Blueprint $table): void {
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/backend/src/database/seeders/ListProjectsSeeder.php
+++ b/backend/src/database/seeders/ListProjectsSeeder.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Seeder;
 use App\Models\ListProjects;
 use App\Models\ContributorListProject;
 use App\Enums\LanguageEnum;
+use App\Enums\ProjectStatusEnum;
 
 class ListProjectsSeeder extends Seeder
 {
@@ -33,6 +34,7 @@ class ListProjectsSeeder extends Seeder
                     ['task' => 'Setup structure', 'done' => true],
                     ['task' => 'Implement authentication', 'done' => false],
                 ],
+                'status' => ProjectStatusEnum::IN_PROGRESS->value,
             ]
         );
 
@@ -51,6 +53,7 @@ class ListProjectsSeeder extends Seeder
                     ['task' => 'Design database', 'done' => true],
                     ['task' => 'Create ui components', 'done' => false],
                 ],
+                'status' => ProjectStatusEnum::IN_PROGRESS->value,
             ]
         );
         
@@ -69,6 +72,7 @@ class ListProjectsSeeder extends Seeder
                     ['task' => 'Setup CI/CD pipeline', 'done' => true],
                     ['task' => 'Implement user roles', 'done' => false],
                 ],
+                'status' => ProjectStatusEnum::IN_PROGRESS->value,
             ]
         );
     }

--- a/backend/src/tests/Feature/ListProjects/ProjectStatusTest.php
+++ b/backend/src/tests/Feature/ListProjects/ProjectStatusTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\ListProjects;
+
+use App\Enums\ProjectStatusEnum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ProjectStatusTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    public function test_status_column_exists(): void
+    {
+        $this->assertTrue(Schema::hasColumn('list_projects', 'status'));
+    }
+
+    public function test_status_default_is_in_progress(): void
+    {
+        $owner = \App\Models\User::first() ?? \App\Models\User::factory()->create();
+        $project = \App\Models\ListProjects::create([
+            'user_id' => $owner->id,
+            'title' => 'Test Project',
+            'time_duration' => '1 month',
+            'language_backend' => 'PHP',
+            'language_frontend' => 'JavaScript',
+            'dev_front_number' => 1,
+            'dev_back_number' => 1,
+        ]);
+
+        $project->refresh();
+        
+        $this->assertEquals(ProjectStatusEnum::IN_PROGRESS, $project->status);
+    }
+}


### PR DESCRIPTION
## Description 
This PR adds a new "status" field to projects. Now we can know if a project is still **in progress** or already **completed**. 

This is going to be necessary for the api call at: https://github.com/IT-Academy-BCN/ita-wiki-monorepo/issues/819. This sets things up for the "Mark as complete" button to work properly and the app can return projects accordingly. 

The default value is "in progress"

##  **⚠️ NOTE** 
### About the test
The test creates the model directly instead of using the factory because the factory generates a random status, which would make the test non-deterministic. We also use `refresh()` after creation because Eloquent doesn't load database defaults into the model automatically — without it, the test would fail since the status would be null instead of the default IN_PROGRESS.