### PR TITLE
feat: add LeagueNotificationModal UI component

### DIFF
--- a/frontend/src/components/Modal/LeagueNotificationModal.test.tsx
+++ b/frontend/src/components/Modal/LeagueNotificationModal.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LeagueNotificationModal } from "./LeagueNotificationModal";
+
+describe("LeagueNotificationModal", () => {
+  it("renders correctly and calls onDismiss on click", () => {
+    const handleDismiss = vi.fn();
+    render(
+      <LeagueNotificationModal
+        direction="up"
+        newLeagueId={2}
+        onDismiss={handleDismiss}
+      />,
+    );
+
+    // Verifica que se renderiza con el texto esperado en catalán
+    expect(screen.getByText("Felicitats!")).toBeInTheDocument();
+    expect(screen.getByText("Silver")).toBeInTheDocument();
+    expect(
+      screen.getByText(/El teu esforç ha donat fruits!/i),
+    ).toBeInTheDocument();
+
+    // Verifica la interacción
+    const button = screen.getByText("D'acord");
+    fireEvent.click(button);
+
+    expect(handleDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Modal/LeagueNotificationModal.test.tsx
+++ b/frontend/src/components/Modal/LeagueNotificationModal.test.tsx
@@ -13,14 +13,12 @@ describe("LeagueNotificationModal", () => {
       />,
     );
 
-    // Verifica que se renderiza con el texto esperado en catalán
     expect(screen.getByText("Felicitats!")).toBeInTheDocument();
     expect(screen.getByText("Silver")).toBeInTheDocument();
     expect(
       screen.getByText(/El teu esforç ha donat fruits!/i),
     ).toBeInTheDocument();
 
-    // Verifica la interacción
     const button = screen.getByText("D'acord");
     fireEvent.click(button);
 

--- a/frontend/src/components/Modal/LeagueNotificationModal.tsx
+++ b/frontend/src/components/Modal/LeagueNotificationModal.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+
+interface LeagueNotificationModalProps {
+  direction: "up" | "down";
+  newLeagueId: number;
+  onDismiss: () => void;
+}
+
+const LEAGUE_NAMES: Record<number, string> = {
+  1: "Bronze",
+  2: "Silver",
+  3: "Gold",
+};
+
+export const LeagueNotificationModal = ({
+  direction,
+  newLeagueId,
+  onDismiss,
+}: LeagueNotificationModalProps) => {
+  const leagueName = LEAGUE_NAMES[newLeagueId] || "Desconeguda";
+  const isUp = direction === "up";
+
+  const title = isUp ? "Felicitats!" : "Atenció";
+
+  const content = useMemo(() => {
+    if (isUp) {
+      return (
+        <div className="flex flex-col items-center text-center space-y-4">
+          <div className="text-4xl">🎉</div>
+          <p className="text-gray-700 text-lg">
+            El teu esforç ha donat fruits! Has pujat a la lliga{" "}
+            <strong className="text-black font-bold">{leagueName}</strong>.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col items-center text-center space-y-4">
+        <div className="text-4xl">📉</div>
+        <p className="text-gray-700 text-lg">
+          Aquesta setmana no ha estat la millor. Has baixat a la lliga{" "}
+          <strong className="text-black font-bold">{leagueName}</strong>.
+        </p>
+      </div>
+    );
+  }, [isUp, leagueName]);
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex justify-center items-center z-50">
+      <div className="bg-white p-6 rounded-2xl w-[90%] sm:w-[50%] md:w-[35%] min-h-[35%] relative">
+        <div className="flex flex-col justify-center items-center w-full mt-10">
+          <h2 className="text-[1.7rem] text-black font-extrabold mb-10">
+            {title}
+          </h2>
+          {content}
+          <div className="mt-8 flex justify-center w-full">
+            <button
+              onClick={onDismiss}
+              className="bg-black text-white px-8 py-3 rounded-full font-semibold hover:bg-gray-800 transition-colors w-full sm:w-auto cursor-pointer"
+            >
+              D'acord
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Modal/LeagueNotificationModal.tsx
+++ b/frontend/src/components/Modal/LeagueNotificationModal.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 interface LeagueNotificationModalProps {
   direction: "up" | "down";
   newLeagueId: number;
@@ -22,20 +20,19 @@ export const LeagueNotificationModal = ({
 
   const title = isUp ? "Felicitats!" : "Atenció";
 
-  const content = useMemo(() => {
-    if (isUp) {
-      return (
-        <div className="flex flex-col items-center text-center space-y-4">
-          <div className="text-4xl">🎉</div>
-          <p className="text-gray-700 text-lg">
-            El teu esforç ha donat fruits! Has pujat a la lliga{" "}
-            <strong className="text-black font-bold">{leagueName}</strong>.
-          </p>
-        </div>
-      );
-    }
-
-    return (
+  let content;
+  if (isUp) {
+    content = (
+      <div className="flex flex-col items-center text-center space-y-4">
+        <div className="text-4xl">🎉</div>
+        <p className="text-gray-700 text-lg">
+          El teu esforç ha donat fruits! Has pujat a la lliga{" "}
+          <strong className="text-black font-bold">{leagueName}</strong>.
+        </p>
+      </div>
+    );
+  } else {
+    content = (
       <div className="flex flex-col items-center text-center space-y-4">
         <div className="text-4xl">📉</div>
         <p className="text-gray-700 text-lg">
@@ -44,7 +41,7 @@ export const LeagueNotificationModal = ({
         </p>
       </div>
     );
-  }, [isUp, leagueName]);
+  }
 
   return (
     <div className="fixed inset-0 bg-black/30 flex justify-center items-center z-50">

--- a/frontend/src/components/Modal/LeagueNotificationModal.tsx
+++ b/frontend/src/components/Modal/LeagueNotificationModal.tsx
@@ -20,28 +20,20 @@ export const LeagueNotificationModal = ({
 
   const title = isUp ? "Felicitats!" : "Atenció";
 
-  let content;
-  if (isUp) {
-    content = (
-      <div className="flex flex-col items-center text-center space-y-4">
-        <div className="text-4xl">🎉</div>
-        <p className="text-gray-700 text-lg">
-          El teu esforç ha donat fruits! Has pujat a la lliga{" "}
-          <strong className="text-black font-bold">{leagueName}</strong>.
-        </p>
-      </div>
-    );
-  } else {
-    content = (
-      <div className="flex flex-col items-center text-center space-y-4">
-        <div className="text-4xl">📉</div>
-        <p className="text-gray-700 text-lg">
-          Aquesta setmana no ha estat la millor. Has baixat a la lliga{" "}
-          <strong className="text-black font-bold">{leagueName}</strong>.
-        </p>
-      </div>
-    );
-  }
+  const icon = isUp ? "🎉" : "📉";
+  const message = isUp
+    ? "El teu esforç ha donat fruits! Has pujat a la lliga "
+    : "Aquesta setmana no ha estat la millor. Has baixat a la lliga ";
+
+  const content = (
+    <div className="flex flex-col items-center text-center space-y-4">
+      <div className="text-4xl">{icon}</div>
+      <p className="text-gray-700 text-lg">
+        {message}
+        <strong className="text-black font-bold">{leagueName}</strong>.
+      </p>
+    </div>
+  );
 
   return (
     <div className="fixed inset-0 bg-black/30 flex justify-center items-center z-50">


### PR DESCRIPTION
## Description
Creates the LeagueNotificationModal UI component to display weekly league transition results to the user.

## Context: 
This PR corresponds to the visual representation of the notification (Child 4 of US #833). It is completely independent and acts as a "dumb component". It receives props from its parent and does not contain API fetching logic or global state context (which will be implemented in the final PR).

## Changes included:

- Created LeagueNotificationModal component reusing the project's modal visual layout.
- Decoupled from the base Modal.tsx to force user interaction (removed "X" close button and backdrop click dismissal).
- Translated copies to Catalan with a motivating tone.
- Added strict happy-path rendering test using Vitest and React Testing Library.

## How to test
Since the component is not yet injected into App.tsx (next PR), you can verify it locally by running its unit tests:

Checkout this branch: git checkout feature/833-4-notification-modal
Enter the frontend container or local environment.

Run the isolated test:
```bash
npm test src/components/Modal/LeagueNotificationModal.test.tsx
```
Verify that the test passes and strictly covers the successful rendering and UI interaction.