### PR TITLE
feat: add notification_dismissed column to ligas table

### DIFF
--- a/backend/src/app/Models/Liga.php
+++ b/backend/src/app/Models/Liga.php
@@ -21,18 +21,21 @@ class Liga extends Model
         'status',
         'language',
         'league_id',
+        'notification_dismissed',
     ];
 
     protected $attributes = [
-        'points_weekly'=> 0,
-        'status'=> 'Junior Coder',
+        'points_weekly' => 0,
+        'status' => 'Junior Coder',
+        'notification_dismissed' => true,
     ];
 
     protected $casts = [
-        'points'=> 'integer',
-        'points_weekly'=> 'integer',
-        'league_id'=> LeagueTypeEnum::class,
-        'status'=> LigaStatusEnum::class, 
+        'points' => 'integer',
+        'points_weekly' => 'integer',
+        'league_id' => LeagueTypeEnum::class,
+        'status' => LigaStatusEnum::class, 
+        'notification_dismissed' => 'boolean',
     ];
 
     public function user(): BelongsTo

--- a/backend/src/database/factories/LigaFactory.php
+++ b/backend/src/database/factories/LigaFactory.php
@@ -24,6 +24,7 @@ class LigaFactory extends Factory
             'language'      => fake()->randomElement(LanguageEnum::values()),
             'status'        => fake()->randomElement(LigaStatusEnum::values()),
             'league_id'     => fake()->randomElement(LeagueTypeEnum::values()),
+            'notification_dismissed' => true,
         ];
     }
 }

--- a/backend/src/database/migrations/2026_06_23_062718_add_notification_dismissed_to_ligas_table.php
+++ b/backend/src/database/migrations/2026_06_23_062718_add_notification_dismissed_to_ligas_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ligas', function (Blueprint $table) {
+            $table->boolean('notification_dismissed')->default(true)->after('league_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ligas', function (Blueprint $table) {
+            $table->dropColumn('notification_dismissed');
+        });
+    }
+};

--- a/backend/src/tests/Feature/LigaTests/LigaTableTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaTableTest.php
@@ -21,6 +21,7 @@ class LigaTableTest extends TestCase
         $this->assertTrue(Schema::hasColumn('ligas', 'status'));
         $this->assertTrue(Schema::hasColumn('ligas', 'language'));
         $this->assertTrue(Schema::hasColumn('ligas', 'league_id'));
+        $this->assertTrue(Schema::hasColumn('ligas', 'notification_dismissed'));
     }
 
     public function test_points_weekly_defaults_to_zero(): void
@@ -74,6 +75,20 @@ class LigaTableTest extends TestCase
             ? $liga->status->value
             : $liga->status;
         $this->assertEquals('Junior Coder', $statusValue);
+    }
+
+    public function test_notification_dismissed_defaults_to_true(): void
+    {
+        $user = User::factory()->create();
+
+        $liga = Liga::create([
+            'user_id' => $user->id,
+            'points'  => 0,
+        ]);
+
+        $liga->refresh();
+
+        $this->assertTrue($liga->notification_dismissed);
     }
 
     public function test_existing_fields_are_not_affected(): void


### PR DESCRIPTION
## Description
Creates the necessary database changes to support the League Promotion notifications. As part of resolving #833, this PR implements the database migration to store the notification state of a user.

**Architectural Note:** Although tracking this state could theoretically belong in the newly proposed league_weekly_results table, we decided to implement the notification_dismissed flag directly in the ligas table. This decision was made to avoid blocking our workflow, as depending on the league_weekly_results table would require waiting for PR #850 to be merged into develop first (complying with the team's "no branching off branches" rule). The refactor to move it in the future, if deemed necessary by the Lead, is extremely low-effort.

## Changes included:

-Created migration to add notification_dismissed boolean column to the ligas table.
-Default value is true so new users aren't immediately spammed with a fake notification.
-Updated Liga model $fillable, $attributes, and $casts to properly support the new column natively.
-Updated LigaFactory to include the new field.
-Added PHPUnit tests to LigaTableTest to assert the column exists and properly defaults to true when created via Eloquent.

## How to test
Checkout feature/833-a-notification-flag

Run php artisan migrate inside the container.

Run the complete test suite to ensure the new model attributes haven't broken any existing database interactions or factories:
```bash
php artisan test
```
Verify all tests pass globally and the database has the new column.