### PR TITLE
feat(#854): make ticket ID clickable with onViewDetail handler

### DIFF
--- a/frontend/src/components/tickets/TicketList.tsx
+++ b/frontend/src/components/tickets/TicketList.tsx
@@ -6,6 +6,7 @@ const TicketList = ({
   isLoading,
   error,
   onCommentClick,
+  onRowClick,
 }: TicketListProps) => {
   if (isLoading)
     return <p className="text-muted-foreground p-6">Carregant tickets...</p>;

--- a/frontend/src/components/tickets/TicketList.tsx
+++ b/frontend/src/components/tickets/TicketList.tsx
@@ -6,7 +6,7 @@ const TicketList = ({
   isLoading,
   error,
   onCommentClick,
-  onRowClick,
+  onViewDetail,
 }: TicketListProps) => {
   if (isLoading)
     return <p className="text-muted-foreground p-6">Carregant tickets...</p>;
@@ -50,7 +50,7 @@ const TicketList = ({
               key={ticket.id}
               ticket={ticket}
               onCommentClick={onCommentClick}
-              onRowClick={onRowClick}
+              onViewDetail={onViewDetail}
             />
           ))}
         </div>

--- a/frontend/src/components/tickets/TicketList.tsx
+++ b/frontend/src/components/tickets/TicketList.tsx
@@ -50,6 +50,7 @@ const TicketList = ({
               key={ticket.id}
               ticket={ticket}
               onCommentClick={onCommentClick}
+              onRowClick={onRowClick}
             />
           ))}
         </div>

--- a/frontend/src/components/tickets/TicketRow.tsx
+++ b/frontend/src/components/tickets/TicketRow.tsx
@@ -52,13 +52,14 @@ const TicketRow = ({
       role="row"
       className="grid grid-cols-2 sm:grid-cols-[1fr_2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-2 sm:gap-4 px-4 py-4 border-b border-border/60"
     >
-      <div
-        role="cell"
-        className="font-semibold cursor-pointer px-2 py-1 -mx-2 rounded-md transition hover:bg-[#fcecec]"
-        onClick={() => onViewDetail?.(ticket)}
-        title="Veure detall"
-      >
-        {String(ticket.id).padStart(6, "0")}
+      <div role="cell">
+        <button
+          className="font-semibold cursor-pointer px-2 py-1 rounded-md transition hover:bg-[#fcecec]"
+          onClick={() => onViewDetail?.(ticket)}
+          title="Veure detall"
+        >
+          {String(ticket.id).padStart(6, "0")}
+        </button>
       </div>
       <div role="cell" className="truncate">
         {ticket.name}

--- a/frontend/src/components/tickets/TicketRow.tsx
+++ b/frontend/src/components/tickets/TicketRow.tsx
@@ -89,10 +89,12 @@ const TicketRow = ({ ticket, onCommentClick, onRowClick }: TicketRowProps) => {
       <div role="cell">{formatDate(ticket.incident_date)}</div>
       <div role="cell">{ticket.code_connect?.role ?? "-"}</div>
       <div role="cell">
-        <button onClick={(e) => {
-          e.stopPropagation();
-          onCommentClick?.(ticket.id);
-        }}>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onCommentClick?.(ticket.id);
+          }}
+        >
           Comentari
         </button>
       </div>

--- a/frontend/src/components/tickets/TicketRow.tsx
+++ b/frontend/src/components/tickets/TicketRow.tsx
@@ -89,7 +89,12 @@ const TicketRow = ({ ticket, onCommentClick, onRowClick }: TicketRowProps) => {
       <div role="cell">{formatDate(ticket.incident_date)}</div>
       <div role="cell">{ticket.code_connect?.role ?? "-"}</div>
       <div role="cell">
-        <button onClick={() => onCommentClick?.(ticket.id)}>Comentari</button>
+        <button onClick={(e) => {
+          e.stopPropagation();
+          onCommentClick?.(ticket.id);
+        }}>
+          Comentari
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/tickets/TicketRow.tsx
+++ b/frontend/src/components/tickets/TicketRow.tsx
@@ -28,9 +28,10 @@ const formatDate = (date: string) => {
 interface TicketRowProps {
   ticket: ApiTicketData;
   onCommentClick?: (id: number) => void;
+  onRowClick?: (ticket: ApiTicketData) => void;
 }
 
-const TicketRow = ({ ticket, onCommentClick }: TicketRowProps) => {
+const TicketRow = ({ ticket, onCommentClick, onRowClick }: TicketRowProps) => {
   const { updateStatus, updatePriority, isLoading } = useTicketingUpdate();
   const { user } = useUserContext();
   const isAdmin = user?.role === roles.ADMIN || user?.role === roles.SUPERADMIN;
@@ -45,7 +46,8 @@ const TicketRow = ({ ticket, onCommentClick }: TicketRowProps) => {
   return (
     <div
       role="row"
-      className="grid grid-cols-2 sm:grid-cols-[1fr_2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-2 sm:gap-4 px-4 py-4 border-b border-border/60 hover:bg-background/60"
+      className="grid grid-cols-2 sm:grid-cols-[1fr_2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-2 sm:gap-4 px-4 py-4 border-b border-border/60 hover:bg-background/60 cursor-pointer"
+      onClick={() => onRowClick?.(ticket)}
     >
       <div role="cell" className="font-semibold">
         {String(ticket.id).padStart(6, "0")}

--- a/frontend/src/components/tickets/TicketRow.tsx
+++ b/frontend/src/components/tickets/TicketRow.tsx
@@ -28,10 +28,14 @@ const formatDate = (date: string) => {
 interface TicketRowProps {
   ticket: ApiTicketData;
   onCommentClick?: (id: number) => void;
-  onRowClick?: (ticket: ApiTicketData) => void;
+  onViewDetail?: (ticket: ApiTicketData) => void;
 }
 
-const TicketRow = ({ ticket, onCommentClick, onRowClick }: TicketRowProps) => {
+const TicketRow = ({
+  ticket,
+  onCommentClick,
+  onViewDetail,
+}: TicketRowProps) => {
   const { updateStatus, updatePriority, isLoading } = useTicketingUpdate();
   const { user } = useUserContext();
   const isAdmin = user?.role === roles.ADMIN || user?.role === roles.SUPERADMIN;
@@ -46,10 +50,14 @@ const TicketRow = ({ ticket, onCommentClick, onRowClick }: TicketRowProps) => {
   return (
     <div
       role="row"
-      className="grid grid-cols-2 sm:grid-cols-[1fr_2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-2 sm:gap-4 px-4 py-4 border-b border-border/60 hover:bg-background/60 cursor-pointer"
-      onClick={() => onRowClick?.(ticket)}
+      className="grid grid-cols-2 sm:grid-cols-[1fr_2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-2 sm:gap-4 px-4 py-4 border-b border-border/60"
     >
-      <div role="cell" className="font-semibold">
+      <div
+        role="cell"
+        className="font-semibold cursor-pointer px-2 py-1 -mx-2 rounded-md transition hover:bg-[#fcecec]"
+        onClick={() => onViewDetail?.(ticket)}
+        title="Veure detall"
+      >
         {String(ticket.id).padStart(6, "0")}
       </div>
       <div role="cell" className="truncate">
@@ -89,14 +97,7 @@ const TicketRow = ({ ticket, onCommentClick, onRowClick }: TicketRowProps) => {
       <div role="cell">{formatDate(ticket.incident_date)}</div>
       <div role="cell">{ticket.code_connect?.role ?? "-"}</div>
       <div role="cell">
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onCommentClick?.(ticket.id);
-          }}
-        >
-          Comentari
-        </button>
+        <button onClick={() => onCommentClick?.(ticket.id)}>Comentari</button>
       </div>
     </div>
   );

--- a/frontend/src/components/tickets/__test__/TicketRow.test.tsx
+++ b/frontend/src/components/tickets/__test__/TicketRow.test.tsx
@@ -76,13 +76,13 @@ describe("TicketRow", () => {
     expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 
-  it("calls onRowClick with the ticket when the row is clicked", () => {
-    const onRowClickMock = vi.fn();
+  it("calls onViewDetail with the ticket when the ID is clicked", () => {
+    const onViewDetailMock = vi.fn();
     renderWithContext(
-      <TicketRow ticket={mockTicket} onRowClick={onRowClickMock} />,
+      <TicketRow ticket={mockTicket} onViewDetail={onViewDetailMock} />,
     );
 
-    fireEvent.click(screen.getByRole("row"));
-    expect(onRowClickMock).toHaveBeenCalledWith(mockTicket);
+    fireEvent.click(screen.getByText("000001"));
+    expect(onViewDetailMock).toHaveBeenCalledWith(mockTicket);
   });
 });

--- a/frontend/src/components/tickets/__test__/TicketRow.test.tsx
+++ b/frontend/src/components/tickets/__test__/TicketRow.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import TicketRow from "../TicketRow";
 import type { ApiTicketData } from "../../../types/ticketingTypes";
@@ -74,5 +74,15 @@ describe("TicketRow", () => {
   it("should render - when category is null", () => {
     renderWithContext(<TicketRow ticket={{ ...mockTicket, category: null }} />);
     expect(screen.getAllByText("-").length).toBeGreaterThan(0);
+  });
+
+  it("calls onRowClick with the ticket when the row is clicked", () => {
+    const onRowClickMock = vi.fn();
+    renderWithContext(
+      <TicketRow ticket={mockTicket} onRowClick={onRowClickMock} />,
+    );
+
+    fireEvent.click(screen.getByRole("row"));
+    expect(onRowClickMock).toHaveBeenCalledWith(mockTicket);
   });
 });

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -74,6 +74,7 @@ export type TicketListProps = {
   isLoading?: boolean;
   error?: string | null;
   onCommentClick?: (id: number) => void;
+  onRowClick?: (ticket: ApiTicketData) => void;
 };
 
 export interface TicketUserData {

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -74,7 +74,7 @@ export type TicketListProps = {
   isLoading?: boolean;
   error?: string | null;
   onCommentClick?: (id: number) => void;
-  onRowClick?: (ticket: ApiTicketData) => void;
+  onViewDetail?: (ticket: ApiTicketData) => void;
 };
 
 export interface TicketUserData {


### PR DESCRIPTION
### Context
This is part of a 3-PR series implementing the ticket detail feature:
- **PR #854 (this one):** adds the clickable ID button with `onViewDetail` handler
- **PR #855:** wires up the modal and shows ticket fields (ID, status, priority, category, date, role)
- **PR #856:** adds the comment section inside the modal

### Description
Makes the ticket ID cell clickable by adding an `onViewDetail` prop to `TicketRow`. Uses a `<button>` with hover styling consistent with the project's existing dropdown buttons (`hover:bg-[#fcecec]`, `rounded-md`). A native tooltip (`title="Veure detall"`) clarifies the interaction. `TicketList` passes the prop through. The modal itself is wired up in PR #855.

### Out of scope
- Modal content
- TicketingPage state management

### Acceptance criteria
- Clicking the ticket ID calls `onViewDetail` with the correct ticket
- Hover style matches the project's dropdown button convention
- Test included

> **Note:** In the GIF the cursor pointer may not be visible — this is a screen recording tool limitation, not a code issue. The pointer and hover effect are fully implemented.
<img width="1200" height="635" alt="Grabación de pantalla 2026-06-24 a las 11 42 24" src="https://github.com/user-attachments/assets/26a41a86-383f-4d01-9f37-3aa556e707b1" />

