### PR TITLE
feat(#855): add ticket detail modal skeleton

### DIFF
--- a/frontend/src/components/tickets/TicketDetailModal.tsx
+++ b/frontend/src/components/tickets/TicketDetailModal.tsx
@@ -12,11 +12,10 @@ const TicketDetailModal = ({
   isOpen,
   onClose,
 }: TicketDetailModalProps) => {
-  if (!ticket) return null;
 
   return (
     <GenericModal isOpen={isOpen} onClose={onClose} size="lg">
-      <p>{String(ticket.id).padStart(6, "0")}</p>
+      {ticket && <p>{String(ticket.id).padStart(6, "0")}</p>}
     </GenericModal>
   );
 };

--- a/frontend/src/components/tickets/TicketDetailModal.tsx
+++ b/frontend/src/components/tickets/TicketDetailModal.tsx
@@ -12,7 +12,6 @@ const TicketDetailModal = ({
   isOpen,
   onClose,
 }: TicketDetailModalProps) => {
-
   return (
     <GenericModal isOpen={isOpen} onClose={onClose} size="lg">
       {ticket && <p>{String(ticket.id).padStart(6, "0")}</p>}

--- a/frontend/src/components/tickets/TicketDetailModal.tsx
+++ b/frontend/src/components/tickets/TicketDetailModal.tsx
@@ -1,0 +1,24 @@
+import GenericModal from "../ui/Modal/GenericModal";
+import type { ApiTicketData } from "../../types/ticketingTypes";
+
+interface TicketDetailModalProps {
+  ticket: ApiTicketData | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const TicketDetailModal = ({
+  ticket,
+  isOpen,
+  onClose,
+}: TicketDetailModalProps) => {
+  if (!ticket) return null;
+
+  return (
+    <GenericModal isOpen={isOpen} onClose={onClose} size="lg">
+      <p>{String(ticket.id).padStart(6, "0")}</p>
+    </GenericModal>
+  );
+};
+
+export default TicketDetailModal;

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -102,7 +102,7 @@ const TicketingPage = (): JSX.Element => {
           isLoading={isLoading}
           error={errorMessage}
           onCommentClick={setSelectedTicketId}
-          onRowClick={(ticket) => {
+          onViewDetail={(ticket) => {
             setSelectedTicket(ticket);
             setIsModalOpen(true);
           }}

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -9,7 +9,12 @@ import { useTicketComments } from "../hooks/useTicketComments";
 import TicketList from "../components/tickets/TicketList";
 import { useUserContext } from "../context/UserContext";
 import { STATUS_LABELS } from "../components/tickets/ticketConstants";
-import type { IntCreateTicket, TicketStatus } from "../types/ticketingTypes";
+import type {
+  IntCreateTicket,
+  TicketStatus,
+  ApiTicketData,
+} from "../types/ticketingTypes";
+import TicketDetailModal from "../components/tickets/TicketDetailModal";
 
 const DEFAULT_STATUSES: TicketStatus[] = ["pending", "in_progress"];
 
@@ -17,6 +22,9 @@ const TicketingPage = (): JSX.Element => {
   const { submitTicketing } = useCreateTicketing();
   const { tickets, isLoading, errorMessage, refetch } = useTicketingGetAll();
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+  const [selectedTicket, setSelectedTicket] = useState<ApiTicketData | null>(
+    null,
+  );
   const { user } = useUserContext();
   const currentUserId = user?.id;
   const [statusFilter, setStatusFilter] =
@@ -93,6 +101,12 @@ const TicketingPage = (): JSX.Element => {
           isLoading={isLoading}
           error={errorMessage}
           onCommentClick={setSelectedTicketId}
+          onRowClick={setSelectedTicket}
+        />
+        <TicketDetailModal
+          ticket={selectedTicket}
+          isOpen={selectedTicket !== null}
+          onClose={() => setSelectedTicket(null)}
         />
         {selectedTicketId !== null && (
           <TicketCommentForm

--- a/frontend/src/pages/TicketingPage.tsx
+++ b/frontend/src/pages/TicketingPage.tsx
@@ -21,6 +21,7 @@ const DEFAULT_STATUSES: TicketStatus[] = ["pending", "in_progress"];
 const TicketingPage = (): JSX.Element => {
   const { submitTicketing } = useCreateTicketing();
   const { tickets, isLoading, errorMessage, refetch } = useTicketingGetAll();
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
   const [selectedTicket, setSelectedTicket] = useState<ApiTicketData | null>(
     null,
@@ -101,12 +102,15 @@ const TicketingPage = (): JSX.Element => {
           isLoading={isLoading}
           error={errorMessage}
           onCommentClick={setSelectedTicketId}
-          onRowClick={setSelectedTicket}
+          onRowClick={(ticket) => {
+            setSelectedTicket(ticket);
+            setIsModalOpen(true);
+          }}
         />
         <TicketDetailModal
           ticket={selectedTicket}
-          isOpen={selectedTicket !== null}
-          onClose={() => setSelectedTicket(null)}
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
         />
         {selectedTicketId !== null && (
           <TicketCommentForm

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -124,7 +124,7 @@ describe("TicketingPage", () => {
     fireEvent.click(screen.getByTestId("ticket-list-item"));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
-    
+
   it("it renders 'suggeriments' button", () => {
     render(<TicketingPage />);
     const button = screen.getByRole("button", { name: "Veure suggeriments" });

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -16,13 +16,17 @@ vi.mock("../../hooks/useCreateTicketing", () => ({
   useCreateTicketing: () => ({ submitTicketing: mockSubmitTicketing }),
 }));
 vi.mock("../../components/tickets/TicketList", () => ({
-  default: ({ tickets, isLoading, error }: TicketListProps) => {
+  default: ({ tickets, isLoading, error, onRowClick }: TicketListProps) => {
     if (isLoading) return <p>Carregant tickets...</p>;
     if (error) return <p>{error}</p>;
     return (
       <div data-testid="ticket-list">
         {tickets.map((t) => (
-          <div key={t.id} data-testid="ticket-list-item" />
+          <div
+            key={t.id}
+            data-testid="ticket-list-item"
+            onClick={() => onRowClick?.(t)}
+          />
         ))}
       </div>
     );
@@ -42,6 +46,11 @@ vi.mock("../../components/ticketing/TicketingCreateForm", () => ({
 
 vi.mock("../../context/UserContext", () => ({
   useUserContext: () => ({ user: { id: 7 } }),
+}));
+
+vi.mock("../../components/tickets/TicketDetailModal", () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role="dialog">Modal</div> : null,
 }));
 
 const mockHook = vi.mocked(useTicketingGetAll);
@@ -106,5 +115,13 @@ describe("TicketingPage", () => {
     const blockedCheckbox = screen.getByLabelText("Bloquejat");
     fireEvent.click(blockedCheckbox);
     expect(screen.getAllByTestId("ticket-list-item")).toHaveLength(3);
+  });
+
+  it("opens modal when a ticket row is clicked", () => {
+    const ticket = { id: 1, status: "pending" } as ApiTicketData;
+    mockHook.mockReturnValue(hookReturn({ tickets: [ticket] }));
+    render(<TicketingPage />);
+    fireEvent.click(screen.getByTestId("ticket-list-item"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__test__/TicketingPage.test.tsx
+++ b/frontend/src/pages/__test__/TicketingPage.test.tsx
@@ -16,7 +16,7 @@ vi.mock("../../hooks/useCreateTicketing", () => ({
   useCreateTicketing: () => ({ submitTicketing: mockSubmitTicketing }),
 }));
 vi.mock("../../components/tickets/TicketList", () => ({
-  default: ({ tickets, isLoading, error, onRowClick }: TicketListProps) => {
+  default: ({ tickets, isLoading, error, onViewDetail }: TicketListProps) => {
     if (isLoading) return <p>Carregant tickets...</p>;
     if (error) return <p>{error}</p>;
     return (
@@ -25,7 +25,7 @@ vi.mock("../../components/tickets/TicketList", () => ({
           <div
             key={t.id}
             data-testid="ticket-list-item"
-            onClick={() => onRowClick?.(t)}
+            onClick={() => onViewDetail?.(t)}
           />
         ))}
       </div>

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -74,6 +74,7 @@ export type TicketListProps = {
   isLoading?: boolean;
   error?: string | null;
   onCommentClick?: (id: number) => void;
+  onRowClick?: (ticket: ApiTicketData) => void;
 };
 
 export interface TicketUserData {

--- a/frontend/src/types/ticketingTypes.ts
+++ b/frontend/src/types/ticketingTypes.ts
@@ -74,7 +74,7 @@ export type TicketListProps = {
   isLoading?: boolean;
   error?: string | null;
   onCommentClick?: (id: number) => void;
-  onRowClick?: (ticket: ApiTicketData) => void;
+  onViewDetail?: (ticket: ApiTicketData) => void;
 };
 
 export interface TicketUserData {


### PR DESCRIPTION
### Description
Creates `TicketDetailModal` component and wires it up in `TicketingPage`. Clicking a ticket row opens a modal showing the ticket ID. Modal can be closed. Fields and styling will be added in the next PR.

### Out of scope
- Ticket fields (status, priority, category, date, role)
- Styling and layout
- Comment section

### Acceptance criteria
- Clicking a ticket row opens `GenericModal`
- The modal shows the ticket ID
- The modal can be closed
- Test included

**Note:** `onRowClick` is duplicated in `TicketListProps` here because PR #854 (which adds it) hasn't been merged to develop yet. This will generate a trivial conflict to resolve when #854 merges.