### PR TITLE
updated TicketFactory with 'category'

### DIFF
--- a/backend/src/database/factories/TicketFactory.php
+++ b/backend/src/database/factories/TicketFactory.php
@@ -8,6 +8,7 @@ use App\Enums\TicketTypeEnum;
 use App\Enums\AffectedAppEnum;
 use App\Enums\AffectedFunctionEnum;
 use App\Enums\TicketPriorityEnum;
+use App\Enums\TicketCategoryEnum;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -32,6 +33,8 @@ class TicketFactory extends Factory
             'description' => fake()->paragraph(),
             'status' => TicketStatusEnum::Pending->value,
             'priority' => fake()->randomElement(TicketPriorityEnum::values()),
+            'category' => fake()->randomElement(TicketCategoryEnum::values()),
+
         ];
 
     }


### PR DESCRIPTION
### Description: 
_Added 'category' field to Ticket Factory._ 

### why is this relevant? 
For demo and UI testing purposes while developing a filtering by category button. Currently, only newly created ticket hold category value. 

<img width="3053" height="1881" alt="Screenshot 2026-06-18 111513" src="https://github.com/user-attachments/assets/b869a95f-7a91-4bdb-8d1b-b12518af0c6b" />
