### PR TITLE
Feature/834 notification endpoints

### DIFF
--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -126,37 +126,25 @@ class LigaController extends Controller
 
     public function getNotification(Request $request): JsonResponse
     {
-        $userId = $request->user()->id;
-
-        $latestResult = \App\Models\LeagueWeeklyResult::where('user_id', $userId)
-            ->orderBy('year', 'desc')
-            ->orderBy('week_number', 'desc')
+        $recentChange = \App\Models\LeagueWeeklyResult::where('user_id', $request->user()->id)
+            ->where('created_at', '>=', now()->subDay())
+            ->whereColumn('from_league', '!=', 'to_league')
+            ->latest()
             ->first();
 
-        if (!$latestResult) {
+        if (!$recentChange) {
             return response()->json(['hasChange' => false]);
         }
 
-        $fromLeagueId = $latestResult->from_league;
-        $toLeagueId = $latestResult->to_league;
-
-        if ($fromLeagueId === $toLeagueId) {
-            return response()->json(['hasChange' => false]);
-        }
-
-        $direction = $toLeagueId > $fromLeagueId ? 'up' : 'down';
-        
-        // Convert ID to name using the Enum if available, otherwise just mapping
-        $leagueNames = [1 => 'Bronze', 2 => 'Silver', 3 => 'Gold', 4 => 'Platinum'];
-        $leagueName = $leagueNames[$toLeagueId] ?? 'Desconeguda';
+        /** @var \App\Enums\LeagueTypeEnum $fromLeague */
+        $fromLeague = $recentChange->from_league;
+        /** @var \App\Enums\LeagueTypeEnum $toLeague */
+        $toLeague = $recentChange->to_league;
 
         return response()->json([
-            'hasChange' => true,
-            'direction' => $direction,
-            'leagueName' => $leagueName,
-            'year' => $latestResult->year,
-            'week_number' => $latestResult->week_number,
+            'hasChange'   => true,
+            'direction'   => $toLeague->value > $fromLeague->value ? 'up' : 'down',
+            'leagueName'  => $toLeague->name,
         ]);
     }
 }
-

--- a/backend/src/app/Http/Controllers/LigaController.php
+++ b/backend/src/app/Http/Controllers/LigaController.php
@@ -123,5 +123,40 @@ class LigaController extends Controller
             'message' => 'Weekly transition triggered successfully',
         ]);
     }
+
+    public function getNotification(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        $latestResult = \App\Models\LeagueWeeklyResult::where('user_id', $userId)
+            ->orderBy('year', 'desc')
+            ->orderBy('week_number', 'desc')
+            ->first();
+
+        if (!$latestResult) {
+            return response()->json(['hasChange' => false]);
+        }
+
+        $fromLeagueId = $latestResult->from_league;
+        $toLeagueId = $latestResult->to_league;
+
+        if ($fromLeagueId === $toLeagueId) {
+            return response()->json(['hasChange' => false]);
+        }
+
+        $direction = $toLeagueId > $fromLeagueId ? 'up' : 'down';
+        
+        // Convert ID to name using the Enum if available, otherwise just mapping
+        $leagueNames = [1 => 'Bronze', 2 => 'Silver', 3 => 'Gold', 4 => 'Platinum'];
+        $leagueName = $leagueNames[$toLeagueId] ?? 'Desconeguda';
+
+        return response()->json([
+            'hasChange' => true,
+            'direction' => $direction,
+            'leagueName' => $leagueName,
+            'year' => $latestResult->year,
+            'week_number' => $latestResult->week_number,
+        ]);
+    }
 }
 

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -184,4 +184,5 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/ligas', [LigaController::class, 'store'])->name('ligas.store');
     Route::post('/ligas/trigger-weekly-transition', [LigaController::class, 'triggerWeeklyTransition'])->name('ligas.trigger-weekly-transition');
     Route::get('/ligas/history', [LigaController::class, 'history'])->name('ligas.history');
+    Route::get('/ligas/notification', [LigaController::class, 'getNotification'])->name('ligas.notification');
 });

--- a/backend/src/tests/Feature/LigaTests/LigaNotificationTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaNotificationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\LigaTests;
+
+use App\Models\User;
+use App\Models\LeagueWeeklyResult;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LigaNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_notification_returns_false_if_no_history(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
+
+        $response->assertStatus(200)
+                 ->assertJson(['hasChange' => false]);
+    }
+
+    public function test_get_notification_returns_false_if_no_league_change(): void
+    {
+        $user = User::factory()->create();
+
+        LeagueWeeklyResult::factory()->create([
+            'user_id' => $user->id,
+            'from_league' => 1,
+            'to_league' => 1,
+            'year' => 2026,
+            'week_number' => 25,
+        ]);
+
+        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
+
+        $response->assertStatus(200)
+                 ->assertJson(['hasChange' => false]);
+    }
+
+    public function test_get_notification_returns_true_for_promotion(): void
+    {
+        $user = User::factory()->create();
+
+        LeagueWeeklyResult::factory()->create([
+            'user_id' => $user->id,
+            'from_league' => 1,
+            'to_league' => 2,
+            'year' => 2026,
+            'week_number' => 25,
+        ]);
+
+        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'hasChange' => true,
+                     'direction' => 'up',
+                     'leagueName' => 'Silver',
+                     'year' => 2026,
+                     'week_number' => 25,
+                 ]);
+    }
+
+    public function test_get_notification_returns_true_for_demotion(): void
+    {
+        $user = User::factory()->create();
+
+        LeagueWeeklyResult::factory()->create([
+            'user_id' => $user->id,
+            'from_league' => 3,
+            'to_league' => 2,
+            'year' => 2026,
+            'week_number' => 26,
+        ]);
+
+        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'hasChange' => true,
+                     'direction' => 'down',
+                     'leagueName' => 'Silver',
+                     'year' => 2026,
+                     'week_number' => 26,
+                 ]);
+    }
+}

--- a/backend/src/tests/Feature/LigaTests/LigaNotificationTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaNotificationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\LigaTests;
 
+use App\Enums\LeagueTypeEnum;
 use App\Models\User;
 use App\Models\LeagueWeeklyResult;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -13,79 +14,88 @@ class LigaNotificationTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_get_notification_returns_false_if_no_history(): void
+    public function test_returns_false_when_user_has_no_league_history(): void
     {
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
-
-        $response->assertStatus(200)
-                 ->assertJson(['hasChange' => false]);
+        $this->actingAs($user)
+             ->getJson(route('ligas.notification'))
+             ->assertStatus(200)
+             ->assertJson(['hasChange' => false]);
     }
 
-    public function test_get_notification_returns_false_if_no_league_change(): void
+    public function test_returns_false_when_recent_change_is_same_league(): void
     {
         $user = User::factory()->create();
 
-        LeagueWeeklyResult::factory()->create([
-            'user_id' => $user->id,
-            'from_league' => 1,
-            'to_league' => 1,
-            'year' => 2026,
-            'week_number' => 25,
+        LeagueWeeklyResult::create([
+            'user_id'     => $user->id,
+            'from_league' => LeagueTypeEnum::Bronze,
+            'to_league'   => LeagueTypeEnum::Bronze,
         ]);
 
-        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
-
-        $response->assertStatus(200)
-                 ->assertJson(['hasChange' => false]);
+        $this->actingAs($user)
+             ->getJson(route('ligas.notification'))
+             ->assertStatus(200)
+             ->assertJson(['hasChange' => false]);
     }
 
-    public function test_get_notification_returns_true_for_promotion(): void
+    public function test_returns_false_when_league_change_is_older_than_24h(): void
     {
         $user = User::factory()->create();
 
-        LeagueWeeklyResult::factory()->create([
-            'user_id' => $user->id,
-            'from_league' => 1,
-            'to_league' => 2,
-            'year' => 2026,
-            'week_number' => 25,
+        $record = LeagueWeeklyResult::create([
+            'user_id'     => $user->id,
+            'from_league' => LeagueTypeEnum::Bronze,
+            'to_league'   => LeagueTypeEnum::Silver,
         ]);
+        $record->forceFill(['created_at' => now()->subDays(2)])->save();
 
-        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
-
-        $response->assertStatus(200)
-                 ->assertJson([
-                     'hasChange' => true,
-                     'direction' => 'up',
-                     'leagueName' => 'Silver',
-                     'year' => 2026,
-                     'week_number' => 25,
-                 ]);
+        $this->actingAs($user)
+             ->getJson(route('ligas.notification'))
+             ->assertStatus(200)
+             ->assertJson(['hasChange' => false]);
     }
 
-    public function test_get_notification_returns_true_for_demotion(): void
+    public function test_returns_promotion_when_recent_change_goes_up(): void
     {
         $user = User::factory()->create();
 
-        LeagueWeeklyResult::factory()->create([
-            'user_id' => $user->id,
-            'from_league' => 3,
-            'to_league' => 2,
-            'year' => 2026,
-            'week_number' => 26,
+        LeagueWeeklyResult::create([
+            'user_id'     => $user->id,
+            'from_league' => LeagueTypeEnum::Bronze,
+            'to_league'   => LeagueTypeEnum::Silver,
+            'created_at'  => now()->subHours(6),
         ]);
 
-        $response = $this->actingAs($user)->getJson(route('ligas.notification'));
+        $this->actingAs($user)
+             ->getJson(route('ligas.notification'))
+             ->assertStatus(200)
+             ->assertJson([
+                 'hasChange'  => true,
+                 'direction'  => 'up',
+                 'leagueName' => 'Silver',
+             ]);
+    }
 
-        $response->assertStatus(200)
-                 ->assertJson([
-                     'hasChange' => true,
-                     'direction' => 'down',
-                     'leagueName' => 'Silver',
-                     'year' => 2026,
-                     'week_number' => 26,
-                 ]);
+    public function test_returns_demotion_when_recent_change_goes_down(): void
+    {
+        $user = User::factory()->create();
+
+        LeagueWeeklyResult::create([
+            'user_id'     => $user->id,
+            'from_league' => LeagueTypeEnum::Gold,
+            'to_league'   => LeagueTypeEnum::Silver,
+            'created_at'  => now()->subHours(1),
+        ]);
+
+        $this->actingAs($user)
+             ->getJson(route('ligas.notification'))
+             ->assertStatus(200)
+             ->assertJson([
+                 'hasChange'  => true,
+                 'direction'  => 'down',
+                 'leagueName' => 'Silver',
+             ]);
     }
 }


### PR DESCRIPTION
## Summary
Adds a GET /ligas/notification endpoint that returns whether the authenticated user has recently changed leagues, using the data from the league_weekly_results table.

Why is this relevant?
The frontend needs a way to know if it should display the league change modal. Instead of storing a "dismissed" flag in the database, the backend simply answers: "Did this user change league this week?". The frontend handles the "already seen" logic via localStorage.

This keeps the backend completely stateless regarding notification read state.

## What does the endpoint return?

If no change:
```bash
json
{ "hasChange": false }
```
If promoted or demoted:
```bash
json
{
  "hasChange": true,
  "direction": "up",
  "leagueName": "Silver",
  "year": 2026,
  "week_number": 25
}
```

## Out of scope
Frontend integration (handled in a separate PR)
Storing dismissed state in the DB (intentionally excluded per team feedback)

Tests included
- Returns hasChange: false if user has no history
- Returns hasChange: false if league didn't change
- Returns hasChange: true with direction: "up" for a promotion
- Returns hasChange: true with direction: "down" for a demotion

Keeping this as a Draft until PR #850 (Lauren's league_weekly_results table) is merged into develop. Will rebase and request review after that.