### PR TITLE
Adds the CloseProjectModal component and connects it to the complete project button

### DIFF
--- a/frontend/src/components/code-connect/CloseProjectModal.tsx
+++ b/frontend/src/components/code-connect/CloseProjectModal.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import GenericModal from "../ui/Modal/GenericModal";
+
+interface CloseProjectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (githubUrl: string, youtubeUrl: string) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+function CloseProjectModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  isSubmitting,
+}: CloseProjectModalProps) {
+  const [githubUrl, setGithubUrl] = useState("");
+  const [youtubeUrl, setYoutubeUrl] = useState("");
+
+  return (
+    <GenericModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Completar projecte"
+      showPrimaryButton
+      primaryButtonText={isSubmitting ? "Guardant..." : "Guardar"}
+      primaryButtonAction={
+        isSubmitting ? undefined : () => onConfirm(githubUrl, youtubeUrl)
+      }
+      showSecondaryButton
+      secondaryButtonText="Cancel·lar"
+      secondaryButtonAction={onClose}
+    >
+      <p className="text-sm text-gray-500 mb-4">
+        Afegeix els enllaços del projecte (opcional)
+      </p>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1 text-left">
+          <label
+            htmlFor="github-url"
+            className="text-sm font-medium text-gray-700"
+          >
+            URL de GitHub
+          </label>
+          <input
+            id="github-url"
+            type="url"
+            value={githubUrl}
+            onChange={(e) => setGithubUrl(e.target.value)}
+            placeholder="https://github.com/..."
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div className="flex flex-col gap-1 text-left">
+          <label
+            htmlFor="youtube-url"
+            className="text-sm font-medium text-gray-700"
+          >
+            URL de YouTube
+          </label>
+          <input
+            id="youtube-url"
+            type="url"
+            value={youtubeUrl}
+            onChange={(e) => setYoutubeUrl(e.target.value)}
+            placeholder="https://youtube.com/..."
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+      </div>
+    </GenericModal>
+  );
+}
+
+export default CloseProjectModal;

--- a/frontend/src/components/code-connect/CloseProjectModal.tsx
+++ b/frontend/src/components/code-connect/CloseProjectModal.tsx
@@ -8,6 +8,15 @@ interface CloseProjectModalProps {
   isSubmitting: boolean;
 }
 
+const isValidUrl = (url: string): boolean => {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 function CloseProjectModal({
   isOpen,
   onClose,
@@ -16,6 +25,26 @@ function CloseProjectModal({
 }: CloseProjectModalProps) {
   const [githubUrl, setGithubUrl] = useState("");
   const [youtubeUrl, setYoutubeUrl] = useState("");
+  const [githubUrlError, setGithubUrlError] = useState("");
+  const [youtubeUrlError, setYoutubeUrlError] = useState("");
+
+  const handleConfirm = () => {
+    const githubError =
+      githubUrl && !isValidUrl(githubUrl)
+        ? "The GitHub URL must be a valid URL."
+        : "";
+    const youtubeError =
+      youtubeUrl && !isValidUrl(youtubeUrl)
+        ? "The YouTube URL must be a valid URL."
+        : "";
+
+    setGithubUrlError(githubError);
+    setYoutubeUrlError(youtubeError);
+
+    if (githubError || youtubeError) return;
+
+    onConfirm(githubUrl, youtubeUrl);
+  };
 
   return (
     <GenericModal
@@ -24,9 +53,7 @@ function CloseProjectModal({
       title="Completar projecte"
       showPrimaryButton
       primaryButtonText={isSubmitting ? "Guardant..." : "Guardar"}
-      primaryButtonAction={
-        isSubmitting ? undefined : () => onConfirm(githubUrl, youtubeUrl)
-      }
+      primaryButtonAction={isSubmitting ? undefined : handleConfirm}
       showSecondaryButton
       secondaryButtonText="Cancel·lar"
       secondaryButtonAction={onClose}
@@ -46,10 +73,16 @@ function CloseProjectModal({
             id="github-url"
             type="url"
             value={githubUrl}
-            onChange={(e) => setGithubUrl(e.target.value)}
+            onChange={(e) => {
+              setGithubUrl(e.target.value);
+              setGithubUrlError("");
+            }}
             placeholder="https://github.com/..."
             className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
           />
+          {githubUrlError && (
+            <p className="text-xs text-red-500">{githubUrlError}</p>
+          )}
         </div>
         <div className="flex flex-col gap-1 text-left">
           <label
@@ -62,10 +95,16 @@ function CloseProjectModal({
             id="youtube-url"
             type="url"
             value={youtubeUrl}
-            onChange={(e) => setYoutubeUrl(e.target.value)}
+            onChange={(e) => {
+              setYoutubeUrl(e.target.value);
+              setYoutubeUrlError("");
+            }}
             placeholder="https://youtube.com/..."
             className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
           />
+          {youtubeUrlError && (
+            <p className="text-xs text-red-500">{youtubeUrlError}</p>
+          )}
         </div>
       </div>
     </GenericModal>

--- a/frontend/src/components/code-connect/__test__/CloseProjectModal.test.tsx
+++ b/frontend/src/components/code-connect/__test__/CloseProjectModal.test.tsx
@@ -11,12 +11,6 @@ const defaultProps = {
 };
 
 describe("CloseProjectModal", () => {
-  it("does not render when isOpen is false", () => {
-    render(<CloseProjectModal {...defaultProps} isOpen={false} />);
-
-    expect(screen.queryByText("Completar projecte")).toBeNull();
-  });
-
   it("renders the title, labels and inputs when isOpen is true", () => {
     render(<CloseProjectModal {...defaultProps} />);
 
@@ -47,110 +41,5 @@ describe("CloseProjectModal", () => {
       "https://github.com/user/project",
       "https://youtube.com/watch?v=123",
     );
-  });
-
-  it("calls onConfirm with empty strings when inputs are not filled", async () => {
-    const onConfirm = vi.fn().mockResolvedValue(undefined);
-    const user = userEvent.setup();
-
-    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
-
-    await user.click(screen.getByRole("button", { name: "Guardar" }));
-
-    expect(onConfirm).toHaveBeenCalledWith("", "");
-  });
-
-  it("shows 'Guardant...' and does not call onConfirm when isSubmitting is true", async () => {
-    const onConfirm = vi.fn();
-    const user = userEvent.setup();
-
-    render(
-      <CloseProjectModal
-        {...defaultProps}
-        onConfirm={onConfirm}
-        isSubmitting={true}
-      />,
-    );
-
-    expect(screen.getByRole("button", { name: "Guardant..." })).toBeTruthy();
-
-    await user.click(screen.getByRole("button", { name: "Guardant..." }));
-
-    expect(onConfirm).not.toHaveBeenCalled();
-  });
-
-  it("calls onClose when clicking Cancel·lar", async () => {
-    const onClose = vi.fn();
-    const user = userEvent.setup();
-
-    render(<CloseProjectModal {...defaultProps} onClose={onClose} />);
-
-    await user.click(screen.getByRole("button", { name: "Cancel·lar" }));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls onClose when clicking the close icon button", async () => {
-    const onClose = vi.fn();
-    const user = userEvent.setup();
-
-    render(<CloseProjectModal {...defaultProps} onClose={onClose} />);
-
-    await user.click(screen.getByRole("button", { name: "Tancar" }));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows an error and does not call onConfirm when github URL is invalid", async () => {
-    const onConfirm = vi.fn();
-    const user = userEvent.setup();
-
-    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
-
-    await user.type(screen.getByLabelText("URL de GitHub"), "not-a-url");
-    await user.click(screen.getByRole("button", { name: "Guardar" }));
-
-    expect(
-      screen.getByText("The GitHub URL must be a valid URL."),
-    ).toBeTruthy();
-    expect(onConfirm).not.toHaveBeenCalled();
-  });
-
-  it("shows an error and does not call onConfirm when youtube URL is invalid", async () => {
-    const onConfirm = vi.fn();
-    const user = userEvent.setup();
-
-    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
-
-    await user.type(screen.getByLabelText("URL de YouTube"), "not-a-url");
-    await user.click(screen.getByRole("button", { name: "Guardar" }));
-
-    expect(
-      screen.getByText("The YouTube URL must be a valid URL."),
-    ).toBeTruthy();
-    expect(onConfirm).not.toHaveBeenCalled();
-  });
-
-  it("clears the error when the user corrects the invalid URL", async () => {
-    const user = userEvent.setup();
-
-    render(<CloseProjectModal {...defaultProps} />);
-
-    await user.type(screen.getByLabelText("URL de GitHub"), "not-a-url");
-    await user.click(screen.getByRole("button", { name: "Guardar" }));
-
-    expect(
-      screen.getByText("The GitHub URL must be a valid URL."),
-    ).toBeTruthy();
-
-    await user.clear(screen.getByLabelText("URL de GitHub"));
-    await user.type(
-      screen.getByLabelText("URL de GitHub"),
-      "https://github.com/user/project",
-    );
-
-    expect(
-      screen.queryByText("The GitHub URL must be a valid URL."),
-    ).toBeNull();
   });
 });

--- a/frontend/src/components/code-connect/__test__/CloseProjectModal.test.tsx
+++ b/frontend/src/components/code-connect/__test__/CloseProjectModal.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import CloseProjectModal from "../CloseProjectModal";
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn().mockResolvedValue(undefined),
+  isSubmitting: false,
+};
+
+describe("CloseProjectModal", () => {
+  it("does not render when isOpen is false", () => {
+    render(<CloseProjectModal {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByText("Completar projecte")).toBeNull();
+  });
+
+  it("renders the title, labels and inputs when isOpen is true", () => {
+    render(<CloseProjectModal {...defaultProps} />);
+
+    expect(screen.getByText("Completar projecte")).toBeTruthy();
+    expect(screen.getByLabelText("URL de GitHub")).toBeTruthy();
+    expect(screen.getByLabelText("URL de YouTube")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Guardar" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel·lar" })).toBeTruthy();
+  });
+
+  it("calls onConfirm with the typed URLs when clicking Guardar", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await user.type(
+      screen.getByLabelText("URL de GitHub"),
+      "https://github.com/user/project",
+    );
+    await user.type(
+      screen.getByLabelText("URL de YouTube"),
+      "https://youtube.com/watch?v=123",
+    );
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      "https://github.com/user/project",
+      "https://youtube.com/watch?v=123",
+    );
+  });
+
+  it("calls onConfirm with empty strings when inputs are not filled", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(onConfirm).toHaveBeenCalledWith("", "");
+  });
+
+  it("shows 'Guardant...' and does not call onConfirm when isSubmitting is true", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <CloseProjectModal
+        {...defaultProps}
+        onConfirm={onConfirm}
+        isSubmitting={true}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Guardant..." })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Guardant..." }));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking Cancel·lar", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Cancel·lar" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when clicking the close icon button", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Tancar" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/code-connect/__test__/CloseProjectModal.test.tsx
+++ b/frontend/src/components/code-connect/__test__/CloseProjectModal.test.tsx
@@ -100,4 +100,57 @@ describe("CloseProjectModal", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("shows an error and does not call onConfirm when github URL is invalid", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await user.type(screen.getByLabelText("URL de GitHub"), "not-a-url");
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(
+      screen.getByText("The GitHub URL must be a valid URL."),
+    ).toBeTruthy();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("shows an error and does not call onConfirm when youtube URL is invalid", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await user.type(screen.getByLabelText("URL de YouTube"), "not-a-url");
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(
+      screen.getByText("The YouTube URL must be a valid URL."),
+    ).toBeTruthy();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("clears the error when the user corrects the invalid URL", async () => {
+    const user = userEvent.setup();
+
+    render(<CloseProjectModal {...defaultProps} />);
+
+    await user.type(screen.getByLabelText("URL de GitHub"), "not-a-url");
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(
+      screen.getByText("The GitHub URL must be a valid URL."),
+    ).toBeTruthy();
+
+    await user.clear(screen.getByLabelText("URL de GitHub"));
+    await user.type(
+      screen.getByLabelText("URL de GitHub"),
+      "https://github.com/user/project",
+    );
+
+    expect(
+      screen.queryByText("The GitHub URL must be a valid URL."),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -14,8 +14,12 @@ const CodeConnectDetails = () => {
   const { user } = useUserContext();
   const [isCompleted, setIsCompleted] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [, setGithubUrl] = useState("");
+  const [, setYoutubeUrl] = useState("");
 
-  const handleConfirm = async () => {
+  const handleConfirm = async (github: string, youtube: string) => {
+    setGithubUrl(github);
+    setYoutubeUrl(youtube);
     setIsCompleted(true);
     setIsModalOpen(false);
   };

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -5,15 +5,17 @@ import PendingRequestList from "../components/code-connect/pendingRequests/Pendi
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
+import { useUserContext } from "../context/UserContext";
 import useCodeConnectDetails from "../hooks/useCodeConnectDetails";
 import { displayLanguageIcon } from "../utils/iconUtils";
 
 const CodeConnectDetails = () => {
   const { projectId } = useParams<{ projectId: string }>();
+  const { user } = useUserContext();
   const [isCompleted, setIsCompleted] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleConfirm = async (_githubUrl: string, _youtubeUrl: string) => {
+  const handleConfirm = async () => {
     setIsCompleted(true);
     setIsModalOpen(false);
   };
@@ -70,19 +72,20 @@ const CodeConnectDetails = () => {
                 "Aquesta informació no està disponible a la base de dades."
               )}
 
-              {!isCompleted ? (
-                <button
-                  type="button"
-                  onClick={() => setIsModalOpen(true)}
-                  className="mt-6 text-primary hover:opacity-80 transition-opacity"
-                >
-                  Marcar com a complet
-                </button>
-              ) : (
-                <span className="mt-6 font-medium text-gray-500 flex items-center gap-1">
-                  ✓ Completat
-                </span>
-              )}
+              {user?.id === codeConnectProject.data.user_id &&
+                (!isCompleted ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsModalOpen(true)}
+                    className="mt-6 text-primary hover:opacity-80 transition-opacity"
+                  >
+                    Marcar com a complet
+                  </button>
+                ) : (
+                  <span className="mt-6 font-medium text-gray-500 flex items-center gap-1">
+                    ✓ Completat
+                  </span>
+                ))}
             </div>
 
             <div className="lg:w-1/3 flex-shrink-0 min-w-[320px] flex lg:justify-end">

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router";
+import CloseProjectModal from "../components/code-connect/CloseProjectModal";
 import PendingRequestList from "../components/code-connect/pendingRequests/PendingRequestList";
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
 import Container from "../components/ui/Container";
@@ -10,6 +11,12 @@ import { displayLanguageIcon } from "../utils/iconUtils";
 const CodeConnectDetails = () => {
   const { projectId } = useParams<{ projectId: string }>();
   const [isCompleted, setIsCompleted] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleConfirm = async (_githubUrl: string, _youtubeUrl: string) => {
+    setIsCompleted(true);
+    setIsModalOpen(false);
+  };
 
   const { codeConnectProject, isLoading, errorMessage } = useCodeConnectDetails(
     projectId || null,
@@ -66,7 +73,7 @@ const CodeConnectDetails = () => {
               {!isCompleted ? (
                 <button
                   type="button"
-                  onClick={() => setIsCompleted(true)}
+                  onClick={() => setIsModalOpen(true)}
                   className="mt-6 text-primary hover:opacity-80 transition-opacity"
                 >
                   Marcar com a complet
@@ -95,6 +102,12 @@ const CodeConnectDetails = () => {
           </div>
         )}
       </Container>
+      <CloseProjectModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleConfirm}
+        isSubmitting={false}
+      />
     </>
   );
 };

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -156,18 +156,6 @@ describe("CodeConnectDetails Page", () => {
     expect(screen.getByText("Marcar com a complet")).toBeTruthy();
   });
 
-  it("does not show the button when the user is not the owner", () => {
-    (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: { data: { ...baseProject, user_id: 99 } },
-      isLoading: false,
-      errorMessage: null,
-    });
-
-    render(<CodeConnectDetails />);
-
-    expect(screen.queryByText("Marcar com a complet")).toBeNull();
-  });
-
   it("opens CloseProjectModal when clicking 'Marcar com a complet'", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
       codeConnectProject: { data: baseProject },
@@ -180,35 +168,5 @@ describe("CodeConnectDetails Page", () => {
     fireEvent.click(screen.getByText("Marcar com a complet"));
 
     expect(screen.getByTestId("close-project-modal")).toBeTruthy();
-  });
-
-  it("shows '✓ Completat' after confirming in the modal", () => {
-    (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: { data: baseProject },
-      isLoading: false,
-      errorMessage: null,
-    });
-
-    render(<CodeConnectDetails />);
-
-    fireEvent.click(screen.getByText("Marcar com a complet"));
-    fireEvent.click(screen.getByText("Confirmar"));
-
-    expect(screen.getByText("✓ Completat")).toBeTruthy();
-  });
-
-  it("closes the modal when clicking Cancel·lar", () => {
-    (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: { data: baseProject },
-      isLoading: false,
-      errorMessage: null,
-    });
-
-    render(<CodeConnectDetails />);
-
-    fireEvent.click(screen.getByText("Marcar com a complet"));
-    fireEvent.click(screen.getByText("Cancel·lar"));
-
-    expect(screen.queryByTestId("close-project-modal")).toBeNull();
   });
 });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -37,6 +37,22 @@ vi.mock("../../utils/iconUtils", () => ({
   displayLanguageIcon: () => "fake-icon.svg",
 }));
 
+vi.mock("../../context/UserContext", () => ({
+  useUserContext: () => ({ user: { id: 1 } }),
+}));
+
+const baseProject = {
+  id: 1,
+  user_id: 1,
+  title: "Projecte Test",
+  description: "Descripció de prova",
+  roadmap: [],
+  contributors: [],
+  time_duration: "2 setmanes",
+  language_frontend: "react",
+  language_backend: "node",
+};
+
 describe("CodeConnectDetails Page", () => {
   it("renders the project title and team when data arrives", () => {
     const mockProjectData = {
@@ -128,19 +144,9 @@ describe("CodeConnectDetails Page", () => {
     expect(screen.getByText("Carregant...")).toBeTruthy();
   });
 
-  it("renders the 'Marcar com a complet' button", () => {
+  it("shows 'Marcar com a complet' button when the user is the owner", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: {
-        data: {
-          title: "Projecte Test",
-          description: "Descripció de prova",
-          roadmap: [],
-          contributors: [],
-          time_duration: "2 setmanes",
-          language_frontend: "react",
-          language_backend: "node",
-        },
-      },
+      codeConnectProject: { data: baseProject },
       isLoading: false,
       errorMessage: null,
     });
@@ -150,19 +156,21 @@ describe("CodeConnectDetails Page", () => {
     expect(screen.getByText("Marcar com a complet")).toBeTruthy();
   });
 
+  it("does not show the button when the user is not the owner", () => {
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: { data: { ...baseProject, user_id: 99 } },
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+
+    expect(screen.queryByText("Marcar com a complet")).toBeNull();
+  });
+
   it("opens CloseProjectModal when clicking 'Marcar com a complet'", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: {
-        data: {
-          title: "Projecte Test",
-          description: "Descripció de prova",
-          roadmap: [],
-          contributors: [],
-          time_duration: "2 setmanes",
-          language_frontend: "react",
-          language_backend: "node",
-        },
-      },
+      codeConnectProject: { data: baseProject },
       isLoading: false,
       errorMessage: null,
     });
@@ -176,17 +184,7 @@ describe("CodeConnectDetails Page", () => {
 
   it("shows '✓ Completat' after confirming in the modal", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: {
-        data: {
-          title: "Projecte Test",
-          description: "Descripció de prova",
-          roadmap: [],
-          contributors: [],
-          time_duration: "2 setmanes",
-          language_frontend: "react",
-          language_backend: "node",
-        },
-      },
+      codeConnectProject: { data: baseProject },
       isLoading: false,
       errorMessage: null,
     });
@@ -201,17 +199,7 @@ describe("CodeConnectDetails Page", () => {
 
   it("closes the modal when clicking Cancel·lar", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: {
-        data: {
-          title: "Projecte Test",
-          description: "Descripció de prova",
-          roadmap: [],
-          contributors: [],
-          time_duration: "2 setmanes",
-          language_frontend: "react",
-          language_backend: "node",
-        },
-      },
+      codeConnectProject: { data: baseProject },
       isLoading: false,
       errorMessage: null,
     });

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, type Mock } from "vitest";
 import useCodeConnectDetails from "../../hooks/useCodeConnectDetails";
@@ -9,6 +8,24 @@ vi.mock("react-router", () => ({
 }));
 
 vi.mock("../../hooks/useCodeConnectDetails");
+
+vi.mock("../../components/code-connect/CloseProjectModal", () => ({
+  default: ({
+    isOpen,
+    onClose,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (g: string, y: string) => Promise<void>;
+  }) =>
+    isOpen ? (
+      <div data-testid="close-project-modal">
+        <button onClick={() => onConfirm("", "")}>Confirmar</button>
+        <button onClick={onClose}>Cancel·lar</button>
+      </div>
+    ) : null,
+}));
 
 vi.mock("../../components/code-connect/projectTeam/ProjectTeam", () => ({
   default: () => (
@@ -111,21 +128,19 @@ describe("CodeConnectDetails Page", () => {
     expect(screen.getByText("Carregant...")).toBeTruthy();
   });
 
-  it("renders the 'Marcar como completado' button", () => {
-    const mockProjectData = {
-      data: {
-        title: "Projecte Test",
-        description: "Descripció de prova",
-        roadmap: [],
-        contributors: [],
-        time_duration: "2 setmanes",
-        language_frontend: "react",
-        language_backend: "node",
-      },
-    };
-
+  it("renders the 'Marcar com a complet' button", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: mockProjectData,
+      codeConnectProject: {
+        data: {
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+        },
+      },
       isLoading: false,
       errorMessage: null,
     });
@@ -135,32 +150,77 @@ describe("CodeConnectDetails Page", () => {
     expect(screen.getByText("Marcar com a complet")).toBeTruthy();
   });
 
-  it("toggles to 'Completat' badge after clicking the button", () => {
-    const mockProjectData = {
-      data: {
-        title: "Projecte Test",
-        description: "Descripció de prova",
-        roadmap: [],
-        contributors: [],
-        time_duration: "2 setmanes",
-        language_frontend: "react",
-        language_backend: "node",
-      },
-    };
-
+  it("opens CloseProjectModal when clicking 'Marcar com a complet'", () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: mockProjectData,
+      codeConnectProject: {
+        data: {
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+        },
+      },
       isLoading: false,
       errorMessage: null,
     });
 
     render(<CodeConnectDetails />);
 
-    const button = screen.getByRole("button", {
-      name: /marcar com a complet/i,
-    });
-    fireEvent.click(button);
+    fireEvent.click(screen.getByText("Marcar com a complet"));
 
-    expect(screen.getByText(/Completat/)).toBeTruthy();
+    expect(screen.getByTestId("close-project-modal")).toBeTruthy();
+  });
+
+  it("shows '✓ Completat' after confirming in the modal", () => {
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: {
+        data: {
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+        },
+      },
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+
+    fireEvent.click(screen.getByText("Marcar com a complet"));
+    fireEvent.click(screen.getByText("Confirmar"));
+
+    expect(screen.getByText("✓ Completat")).toBeTruthy();
+  });
+
+  it("closes the modal when clicking Cancel·lar", () => {
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: {
+        data: {
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+        },
+      },
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+
+    fireEvent.click(screen.getByText("Marcar com a complet"));
+    fireEvent.click(screen.getByText("Cancel·lar"));
+
+    expect(screen.queryByTestId("close-project-modal")).toBeNull();
   });
 });


### PR DESCRIPTION
**### Description**

This PR was divided into 2 PR:
-Creates a new modal for complete projects. Only the modal page (this one) - feature/820-Modal-complete-project-form-1_2
-Connects the "Mark as completed" button in the modal to the backend endpoint added in #819 (the new one) - feature/820-Modal-complete-project-form-2_2

**### Context:**
Currently, anyone can mark a project as completed, but the change isn't persisted (upon returning, it shows as incomplete again). With this PR, we want to ensure that:
- only projects that are not yet completed can be marked as completed.
- only the project owner can mark it as completed.
- clicking to mark it triggers a modal where two URLs can be entered: one for the project repository and another for a YouTube demo.
- all of this is persisted in the database.

**### Files created/modificated**
CloseProjectModal.tsx — new component
CloseProjectModal.test.tsx — 2 tests
CodeConnectDetails.tsx — the button open the modal, onConfirm flag completed locally
CodeConnectDetails.test.tsx — updated tests (open modal, confirm, cancel)