### PR TITLE
fix: correct league label order and mapping in WeeklyRanking

### DIFF
--- a/frontend/src/components/leagues-ranking/WeeklyRanking/WeeklyRanking.tsx
+++ b/frontend/src/components/leagues-ranking/WeeklyRanking/WeeklyRanking.tsx
@@ -7,22 +7,26 @@ type WeeklyRankingProps = {
 
 export const WeeklyRanking = ({ leagues }: WeeklyRankingProps) => {
   const LEAGUE_LABELS: Record<string, string> = {
-    "1": "Or",
+    "1": "Bronze",
     "2": "Plata",
-    "3": "Bronze",
+    "3": "Or",
   };
+
+  const sortedLeagues = leagues
+    ? Object.entries(leagues).sort(([a], [b]) => Number(b) - Number(a))
+    : [];
 
   return (
     <>
       {leagues && (
         <section>
-          {Object.entries(leagues).map(([id, league], index) => (
+          {sortedLeagues.map(([id, league], index) => (
             <div key={id} className="my-10">
               <h1>Lliga {LEAGUE_LABELS[id] ?? id}</h1>
               <LeagueList
                 standings={league}
                 showUp={index > 0}
-                showDown={index + 1 < Object.entries(leagues).length}
+                showDown={index + 1 < sortedLeagues.length}
               />
             </div>
           ))}

--- a/frontend/src/components/leagues-ranking/__test__/WeeklyRanking.test.tsx
+++ b/frontend/src/components/leagues-ranking/__test__/WeeklyRanking.test.tsx
@@ -6,7 +6,7 @@ import type { LigaResponse } from "../../../types/league";
 import { WeeklyRanking } from "../WeeklyRanking/WeeklyRanking";
 
 const mockLeagues: LigaResponse = {
-  "1": [
+  "3": [
     {
       position: 1,
       user_id: 101,
@@ -14,7 +14,7 @@ const mockLeagues: LigaResponse = {
       points_weekly: 94,
       status: "Junior Coder",
       language: "React",
-      league_id: 1,
+      league_id: 3,
     },
   ],
 };


### PR DESCRIPTION
# What does this PR do?

Fixes the league label mapping and display order in the WeeklyRanking component.

# Changes

- Corrected the LEAGUE_LABELS mapping ("1" → Bronze, "2" → Plata, "3" → Or)

- Added sorting to display leagues from highest to lowest (Or → Plata → Bronze)

- Updated WeeklyRanking.test.tsx mock data to reflect the correct league ids

# Context

The backend returns leagues ordered by id ascending (1 = Bronze, 2 = Plata, 3 = Or). This ordering reflects the database structure and should not be changed, as it could affect other consumers of the API.

The display order (Or first, Bronze last) is a UI concern, so the fix belongs in the frontend. The WeeklyRanking component now sorts the entries by id descending before rendering, and the label mapping has been corrected to match the actual backend ids.

# Testing

- All 47 tests passing