### PR TITLE
Connect CloseProjectModal to the backend complete endpoint and his tests

### DIFF
--- a/frontend/src/api/__tests__/endPointCodeConnect.test.ts
+++ b/frontend/src/api/__tests__/endPointCodeConnect.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IntCodeConnect } from "../../types";
 import {
   CodeConnectError,
+  closeCodeConnectProject,
   createCodeConnect,
   fetchCodeConnectAllProjects,
   fetchCodeConnectProject,
@@ -204,6 +205,81 @@ describe("fetchCodeConnectAllProjects", () => {
     mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
     await expect(fetchCodeConnectAllProjects()).rejects.toMatchObject({
+      message: "Error de connexió. Verifica la teva connexió a internet.",
+      code: "NETWORK_ERROR",
+    } as CodeConnectError);
+  });
+});
+
+describe("closeCodeConnectProject", () => {
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call the correct endpoint with PATCH method and token", async () => {
+    localStorage.setItem("auth_token", "test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await closeCodeConnectProject(1, {
+      github_url: "https://github.com/user/project",
+      youtube_url: "https://youtube.com/watch?v=123",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/codeconnect/1/complete",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        }),
+        body: JSON.stringify({
+          github_url: "https://github.com/user/project",
+          youtube_url: "https://youtube.com/watch?v=123",
+        }),
+      }),
+    );
+  });
+
+  it("should not send Authorization header when no token in localStorage", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await closeCodeConnectProject(1, {});
+
+    const calledWithOptions = mockFetch.mock.calls[0][1];
+    expect(calledWithOptions.headers.Authorization).toBeUndefined();
+  });
+
+  it("should throw an error with the backend message on failed request", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: async () => ({ message: "You are not the owner of this project" }),
+    });
+
+    await expect(closeCodeConnectProject(1, {})).rejects.toMatchObject({
+      message: "You are not the owner of this project",
+      status: 403,
+    } as CodeConnectError);
+  });
+
+  it("should throw an error on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    await expect(closeCodeConnectProject(1, {})).rejects.toMatchObject({
       message: "Error de connexió. Verifica la teva connexió a internet.",
       code: "NETWORK_ERROR",
     } as CodeConnectError);

--- a/frontend/src/api/endPointCodeConnect.ts
+++ b/frontend/src/api/endPointCodeConnect.ts
@@ -174,3 +174,57 @@ export const fetchCodeConnectAllProjects = async (
     throw error;
   }
 };
+
+export const closeCodeConnectProject = async (
+  projectId: number,
+  data: { github_url?: string; youtube_url?: string },
+): Promise<ApiProjectResponse> => {
+  const url = `${API_URL}${END_POINTS.codeconnect.get}/${projectId}/complete`;
+  const token = localStorage.getItem("auth_token");
+
+  try {
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Error ${response.status}: ${response.statusText}`;
+      let errorCode: string | undefined;
+
+      try {
+        const errorData = (await response.json()) as {
+          message?: string;
+          code?: string;
+        };
+
+        errorMessage = errorData.message || errorMessage;
+        errorCode = errorData.code;
+      } catch {
+        // Ignore the parsing error and use the default values that have already been set.
+      }
+
+      throw {
+        message: errorMessage,
+        status: response.status,
+        code: errorCode,
+      } as CodeConnectError;
+    }
+
+    return (await response.json()) as ApiProjectResponse;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw {
+        message: "Error de connexió. Verifica la teva connexió a internet.",
+        code: "NETWORK_ERROR",
+      } as CodeConnectError;
+    }
+
+    throw error;
+  }
+};

--- a/frontend/src/components/code-connect/CloseProjectModal.tsx
+++ b/frontend/src/components/code-connect/CloseProjectModal.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import GenericModal from "../ui/Modal/GenericModal";
+
+interface CloseProjectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (githubUrl: string, youtubeUrl: string) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+function CloseProjectModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  isSubmitting,
+}: CloseProjectModalProps) {
+  const [githubUrl, setGithubUrl] = useState("");
+  const [youtubeUrl, setYoutubeUrl] = useState("");
+
+  return (
+    <GenericModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Completar projecte"
+      showPrimaryButton
+      primaryButtonText={isSubmitting ? "Guardant..." : "Guardar"}
+      primaryButtonAction={
+        isSubmitting ? undefined : () => onConfirm(githubUrl, youtubeUrl)
+      }
+      showSecondaryButton
+      secondaryButtonText="Cancel·lar"
+      secondaryButtonAction={onClose}
+    >
+      <p className="text-sm text-gray-500 mb-4">
+        Afegeix els enllaços del projecte (opcional)
+      </p>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1 text-left">
+          <label
+            htmlFor="github-url"
+            className="text-sm font-medium text-gray-700"
+          >
+            URL de GitHub
+          </label>
+          <input
+            id="github-url"
+            type="url"
+            value={githubUrl}
+            onChange={(e) => setGithubUrl(e.target.value)}
+            placeholder="https://github.com/..."
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div className="flex flex-col gap-1 text-left">
+          <label
+            htmlFor="youtube-url"
+            className="text-sm font-medium text-gray-700"
+          >
+            URL de YouTube
+          </label>
+          <input
+            id="youtube-url"
+            type="url"
+            value={youtubeUrl}
+            onChange={(e) => setYoutubeUrl(e.target.value)}
+            placeholder="https://youtube.com/..."
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+      </div>
+    </GenericModal>
+  );
+}
+
+export default CloseProjectModal;

--- a/frontend/src/pages/CodeConnectDetails.tsx
+++ b/frontend/src/pages/CodeConnectDetails.tsx
@@ -1,19 +1,44 @@
 import { useState } from "react";
 import { useParams } from "react-router";
+import { closeCodeConnectProject } from "../api/endPointCodeConnect";
+import CloseProjectModal from "../components/code-connect/CloseProjectModal";
 import PendingRequestList from "../components/code-connect/pendingRequests/PendingRequestList";
 import ProjectTeam from "../components/code-connect/projectTeam/ProjectTeam";
 import Container from "../components/ui/Container";
 import PageTitle from "../components/ui/PageTitle";
+import { useUserContext } from "../context/UserContext";
 import useCodeConnectDetails from "../hooks/useCodeConnectDetails";
 import { displayLanguageIcon } from "../utils/iconUtils";
 
 const CodeConnectDetails = () => {
   const { projectId } = useParams<{ projectId: string }>();
-  const [isCompleted, setIsCompleted] = useState(false);
+  const { user } = useUserContext();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { codeConnectProject, isLoading, errorMessage } = useCodeConnectDetails(
     projectId || null,
   );
+
+  const isOwner = !!user && codeConnectProject?.data?.user_id === user.id;
+  const isCompleted = codeConnectProject?.data?.project_status === "completed";
+
+  const handleConfirm = async (githubUrl: string, youtubeUrl: string) => {
+    if (!codeConnectProject?.data?.id) return;
+    setIsSubmitting(true);
+    try {
+      await closeCodeConnectProject(codeConnectProject.data.id, {
+        github_url: githubUrl || undefined,
+        youtube_url: youtubeUrl || undefined,
+      });
+      setIsModalOpen(false);
+      window.location.reload();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <>
@@ -63,19 +88,20 @@ const CodeConnectDetails = () => {
                 "Aquesta informació no està disponible a la base de dades."
               )}
 
-              {!isCompleted ? (
-                <button
-                  type="button"
-                  onClick={() => setIsCompleted(true)}
-                  className="mt-6 text-primary hover:opacity-80 transition-opacity"
-                >
-                  Marcar com a complet
-                </button>
-              ) : (
-                <span className="mt-6 font-medium text-gray-500 flex items-center gap-1">
-                  ✓ Completat
-                </span>
-              )}
+              {isOwner &&
+                (isCompleted ? (
+                  <span className="mt-6 font-medium text-gray-500 flex items-center gap-1">
+                    ✓ Completat
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setIsModalOpen(true)}
+                    className="mt-6 text-primary hover:opacity-80 transition-opacity"
+                  >
+                    Marcar com a complet
+                  </button>
+                ))}
             </div>
 
             <div className="lg:w-1/3 flex-shrink-0 min-w-[320px] flex lg:justify-end">
@@ -95,6 +121,12 @@ const CodeConnectDetails = () => {
           </div>
         )}
       </Container>
+      <CloseProjectModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleConfirm}
+        isSubmitting={isSubmitting}
+      />
     </>
   );
 };

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../../components/code-connect/CloseProjectModal", () => ({
   }) =>
     isOpen ? (
       <div data-testid="close-project-modal">
-        <button onClick={() => onConfirm("", "")}>Confirmar</button>
+        <button onClick={() => onConfirm("", "")}>Guardar</button>
         <button onClick={onClose}>Cancel·lar</button>
       </div>
     ) : null,
@@ -140,6 +140,8 @@ describe("CodeConnectDetails Page", () => {
   it("renders the 'Marcar como completado' button", () => {
     const mockProjectData = {
       data: {
+        id: 1,
+        user_id: 1,
         title: "Projecte Test",
         description: "Descripció de prova",
         roadmap: [],
@@ -147,6 +149,7 @@ describe("CodeConnectDetails Page", () => {
         time_duration: "2 setmanes",
         language_frontend: "react",
         language_backend: "node",
+        project_status: "in_progress",
       },
     };
 
@@ -161,33 +164,43 @@ describe("CodeConnectDetails Page", () => {
     expect(screen.getByText("Marcar com a complet")).toBeTruthy();
   });
 
-  it("toggles to 'Completat' badge after clicking the button", () => {
-    const mockProjectData = {
-      data: {
-        title: "Projecte Test",
-        description: "Descripció de prova",
-        roadmap: [],
-        contributors: [],
-        time_duration: "2 setmanes",
-        language_frontend: "react",
-        language_backend: "node",
-      },
-    };
-
+  it("closes the modal after clicking Guardar", async () => {
     (useCodeConnectDetails as Mock).mockReturnValue({
-      codeConnectProject: mockProjectData,
+      codeConnectProject: {
+        data: {
+          id: 1,
+          user_id: 1,
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+          project_status: "in_progress",
+        },
+      },
       isLoading: false,
       errorMessage: null,
+    });
+    (closeCodeConnectProject as Mock).mockResolvedValue({});
+    Object.defineProperty(window, "location", {
+      value: { reload: vi.fn() },
+      writable: true,
     });
 
     render(<CodeConnectDetails />);
 
-    const button = screen.getByRole("button", {
-      name: /marcar com a complet/i,
-    });
-    fireEvent.click(button);
+    fireEvent.click(
+      screen.getByRole("button", { name: /marcar com a complet/i }),
+    );
+    expect(screen.getByTestId("close-project-modal")).toBeTruthy();
 
-    expect(screen.getByText(/Completat/)).toBeTruthy();
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("close-project-modal")).toBeNull();
+    });
   });
 
   it("shows '✓ Completat' when project_status is already completed", () => {
@@ -270,7 +283,7 @@ describe("CodeConnectDetails Page", () => {
     render(<CodeConnectDetails />);
 
     fireEvent.click(screen.getByText("Marcar com a complet"));
-    fireEvent.click(screen.getByText("Confirmar"));
+    fireEvent.click(screen.getByText("Guardar"));
 
     await waitFor(() => {
       expect(closeCodeConnectProject).toHaveBeenCalledWith(1, {

--- a/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
+++ b/frontend/src/pages/__test__/CodeConnectDetails.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, type Mock } from "vitest";
+import { closeCodeConnectProject } from "../../api/endPointCodeConnect";
 import useCodeConnectDetails from "../../hooks/useCodeConnectDetails";
 import CodeConnectDetails from "../CodeConnectDetails";
 
@@ -18,6 +18,32 @@ vi.mock("../../components/code-connect/projectTeam/ProjectTeam", () => ({
 
 vi.mock("../../utils/iconUtils", () => ({
   displayLanguageIcon: () => "fake-icon.svg",
+}));
+
+vi.mock("../../context/UserContext", () => ({
+  useUserContext: () => ({ user: { id: 1 } }),
+}));
+
+vi.mock("../../api/endPointCodeConnect", () => ({
+  closeCodeConnectProject: vi.fn(),
+}));
+
+vi.mock("../../components/code-connect/CloseProjectModal", () => ({
+  default: ({
+    isOpen,
+    onClose,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (g: string, y: string) => Promise<void>;
+  }) =>
+    isOpen ? (
+      <div data-testid="close-project-modal">
+        <button onClick={() => onConfirm("", "")}>Confirmar</button>
+        <button onClick={onClose}>Cancel·lar</button>
+      </div>
+    ) : null,
 }));
 
 describe("CodeConnectDetails Page", () => {
@@ -162,5 +188,96 @@ describe("CodeConnectDetails Page", () => {
     fireEvent.click(button);
 
     expect(screen.getByText(/Completat/)).toBeTruthy();
+  });
+
+  it("shows '✓ Completat' when project_status is already completed", () => {
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: {
+        data: {
+          id: 1,
+          user_id: 1,
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+          project_status: "completed",
+        },
+      },
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+
+    expect(screen.getByText("✓ Completat")).toBeTruthy();
+    expect(screen.queryByText("Marcar com a complet")).toBeNull();
+  });
+
+  it("does not show the button when the user is not the owner", () => {
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: {
+        data: {
+          id: 1,
+          user_id: 99,
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+          project_status: "in_progress",
+        },
+      },
+      isLoading: false,
+      errorMessage: null,
+    });
+
+    render(<CodeConnectDetails />);
+
+    expect(screen.queryByText("Marcar com a complet")).toBeNull();
+  });
+
+  it("calls closeCodeConnectProject and reloads when confirming", async () => {
+    (useCodeConnectDetails as Mock).mockReturnValue({
+      codeConnectProject: {
+        data: {
+          id: 1,
+          user_id: 1,
+          title: "Projecte Test",
+          description: "Descripció de prova",
+          roadmap: [],
+          contributors: [],
+          time_duration: "2 setmanes",
+          language_frontend: "react",
+          language_backend: "node",
+          project_status: "in_progress",
+        },
+      },
+      isLoading: false,
+      errorMessage: null,
+    });
+    (closeCodeConnectProject as Mock).mockResolvedValue({});
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+    });
+
+    render(<CodeConnectDetails />);
+
+    fireEvent.click(screen.getByText("Marcar com a complet"));
+    fireEvent.click(screen.getByText("Confirmar"));
+
+    await waitFor(() => {
+      expect(closeCodeConnectProject).toHaveBeenCalledWith(1, {
+        github_url: undefined,
+        youtube_url: undefined,
+      });
+      expect(reloadMock).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -45,6 +45,9 @@ export interface ApiProjectData {
   roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
+  project_status?: "in_progress" | "completed";
+  github_url?: string | null;
+  youtube_url?: string | null;
 }
 
 export interface ApiContributor {


### PR DESCRIPTION
### Description

This PR was divided into 2 PR:
-Creates a new modal for complete projects. Only the modal page (done early) - feature/820-Modal-complete-project-form-1_2
-Connects the "Mark as completed" button in the modal to the backend endpoint added in https://github.com/IT-Academy-BCN/ita-wiki-monorepo/issues/819 (this one) - feature/820-Modal-complete-project-form-2_2

### Context:
Currently, anyone can mark a project as completed, but the change isn't persisted (upon returning, it shows as incomplete again). With this PR, we want to ensure that:

only projects that are not yet completed can be marked as completed.
only the project owner can mark it as completed.
clicking to mark it triggers a modal where two URLs can be entered: one for the project repository and another for a YouTube demo.
all of this is persisted in the database.

### Files created/modificated
endPointCodeConnect.ts — added function closeCodeConnectProject
codeConnectTypes.ts — added 3 new fields to ApiProjectData interface
CodeConnectDetails.tsx — added real conection to the backend
CodeConnectDetails.test.tsx — necesary mocks and 3 new tests
endPointCodeConnect.test.ts — 4 new tests for closeCodeConnectProject

Dependencies

This PR requires #819 (backend endpoint) to be merged first, otherwise the API call will return 404.
This PR requires #820 (modal) to be merged first. File "CloseProjectModal.tsx" is hardcoded for the time being.