### PR TITLE
feat: implement league demotion logic

### DIFF
--- a/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
+++ b/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
@@ -30,6 +30,7 @@ class ProcessLeaguePromotions extends Command
 
         $bronzeCount = Liga::where('league_id', LeagueTypeEnum::Bronze->value)->count();
         $silverCount = Liga::where('league_id', LeagueTypeEnum::Silver->value)->count();
+        $goldCount   = Liga::where('league_id', LeagueTypeEnum::Gold->value)->count();
 
         $bronzeToSilver = $bronzeCount >= 4
             ? Liga::where('league_id', LeagueTypeEnum::Bronze->value)
@@ -45,7 +46,22 @@ class ProcessLeaguePromotions extends Command
             ->pluck('user_id')
             : collect();
 
-        DB::transaction(function () use ($bronzeToSilver, $silverToGold, $year, $weekNumber) {
+        $goldToSilver = $goldCount >= 4
+            ? Liga::where('league_id', LeagueTypeEnum::Gold->value)
+            ->orderBy('points_weekly', 'asc')
+            ->take(3)
+            ->pluck('user_id')
+            : collect();
+
+        $silverToBronze = $silverCount >= 7
+            ? Liga::where('league_id', LeagueTypeEnum::Silver->value)
+            ->whereNotIn('user_id', $silverToGold)
+            ->orderBy('points_weekly','asc')
+            ->take(3)
+            ->pluck('user_id')
+            : collect();
+
+        DB::transaction(function () use ($bronzeToSilver, $silverToGold, $goldToSilver, $silverToBronze, $year, $weekNumber) {
             foreach ($bronzeToSilver as $userId) {
                 LeagueWeeklyResult::insertOrIgnore([
                     'user_id'     => $userId,
@@ -70,8 +86,34 @@ class ProcessLeaguePromotions extends Command
                 ]);
             }
 
+            foreach ($goldToSilver as $userId) {
+                LeagueWeeklyResult::insertOrIgnore([
+                    'user_id'     => $userId,
+                    'year'        => $year,
+                    'week_number' => $weekNumber,
+                    'from_league' => LeagueTypeEnum::Gold->value,
+                    'to_league'   => LeagueTypeEnum::Silver->value,
+                    'created_at'  => now(),
+                    'updated_at'  => now(),
+                ]);
+            }
+
+            foreach ($silverToBronze as $userId) {
+                LeagueWeeklyResult::insertOrIgnore([
+                    'user_id'     => $userId,
+                    'year'        => $year,
+                    'week_number' => $weekNumber,
+                    'from_league' => LeagueTypeEnum::Silver->value,
+                    'to_league'   => LeagueTypeEnum::Bronze->value,
+                    'created_at'  => now(),
+                    'updated_at'  => now(),
+                ]);
+            }
+
             Liga::whereIn('user_id', $bronzeToSilver)->update(['league_id' => LeagueTypeEnum::Silver->value]);
             Liga::whereIn('user_id', $silverToGold)->update(['league_id' => LeagueTypeEnum::Gold->value]);
+            Liga::whereIn('user_id', $goldToSilver)->update(['league_id' => LeagueTypeEnum::Silver->value]);
+            Liga::whereIn('user_id', $silverToBronze)->update(['league_id' => LeagueTypeEnum::Bronze->value]);
         });
 
         return self::SUCCESS;

--- a/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
+++ b/backend/src/app/Console/Commands/ProcessLeaguePromotions.php
@@ -9,6 +9,7 @@ use App\Enums\LeagueTypeEnum;
 use App\Models\Liga;
 use App\Models\LeagueWeeklyResult;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Collection;
 
 class ProcessLeaguePromotions extends Command
 {
@@ -20,102 +21,110 @@ class ProcessLeaguePromotions extends Command
         $year = now()->year;
         $weekNumber = now()->isoWeek();
 
-        $alreadyProcessed = LeagueWeeklyResult::where('year', $year)
-            ->where('week_number', $weekNumber)
-            ->exists();
-
-        if ($alreadyProcessed) {
+        if ($this->alreadyProcessed($year, $weekNumber)) {
             return self::SUCCESS;
         }
 
+        [$bronzeToSilver, $silverToGold, $goldToSilver, $silverToBronze] =
+            $this->calculateTransitions();
+
+        $this->applyTransitions(
+            $bronzeToSilver,
+            $silverToGold,
+            $goldToSilver,
+            $silverToBronze,
+            $year,
+            $weekNumber
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function alreadyProcessed(int $year, int $weekNumber): bool
+    {
+        return LeagueWeeklyResult::where('year', $year)
+            ->where('week_number', $weekNumber)
+            ->exists();
+    }
+
+    private function calculateTransitions(): array
+    {
         $bronzeCount = Liga::where('league_id', LeagueTypeEnum::Bronze->value)->count();
         $silverCount = Liga::where('league_id', LeagueTypeEnum::Silver->value)->count();
         $goldCount   = Liga::where('league_id', LeagueTypeEnum::Gold->value)->count();
 
         $bronzeToSilver = $bronzeCount >= 4
             ? Liga::where('league_id', LeagueTypeEnum::Bronze->value)
-            ->orderBy('points_weekly', 'desc')
-            ->take(3)
-            ->pluck('user_id')
+                ->orderBy('points_weekly', 'desc')
+                ->take(3)
+                ->pluck('user_id')
             : collect();
 
         $silverToGold = $silverCount >= 4
             ? Liga::where('league_id', LeagueTypeEnum::Silver->value)
-            ->orderBy('points_weekly', 'desc')
-            ->take(3)
-            ->pluck('user_id')
+                ->orderBy('points_weekly', 'desc')
+                ->take(3)
+                ->pluck('user_id')
             : collect();
 
         $goldToSilver = $goldCount >= 4
             ? Liga::where('league_id', LeagueTypeEnum::Gold->value)
-            ->orderBy('points_weekly', 'asc')
-            ->take(3)
-            ->pluck('user_id')
+                ->orderBy('points_weekly', 'asc')
+                ->take(3)
+                ->pluck('user_id')
             : collect();
 
         $silverToBronze = $silverCount >= 7
             ? Liga::where('league_id', LeagueTypeEnum::Silver->value)
-            ->whereNotIn('user_id', $silverToGold)
-            ->orderBy('points_weekly','asc')
-            ->take(3)
-            ->pluck('user_id')
+                ->whereNotIn('user_id', $silverToGold)
+                ->orderBy('points_weekly', 'asc')
+                ->take(3)
+                ->pluck('user_id')
             : collect();
 
-        DB::transaction(function () use ($bronzeToSilver, $silverToGold, $goldToSilver, $silverToBronze, $year, $weekNumber) {
-            foreach ($bronzeToSilver as $userId) {
-                LeagueWeeklyResult::insertOrIgnore([
-                    'user_id'     => $userId,
-                    'year'        => $year,
-                    'week_number' => $weekNumber,
-                    'from_league' => LeagueTypeEnum::Bronze->value,
-                    'to_league'   => LeagueTypeEnum::Silver->value,
-                    'created_at'  => now(),
-                    'updated_at'  => now(),
-                ]);
-            }
+        return [$bronzeToSilver, $silverToGold, $goldToSilver, $silverToBronze];
+    }
 
-            foreach ($silverToGold as $userId) {
-                LeagueWeeklyResult::insertOrIgnore([
-                    'user_id'     => $userId,
-                    'year'        => $year,
-                    'week_number' => $weekNumber,
-                    'from_league' => LeagueTypeEnum::Silver->value,
-                    'to_league'   => LeagueTypeEnum::Gold->value,
-                    'created_at'  => now(),
-                    'updated_at'  => now(),
-                ]);
-            }
-
-            foreach ($goldToSilver as $userId) {
-                LeagueWeeklyResult::insertOrIgnore([
-                    'user_id'     => $userId,
-                    'year'        => $year,
-                    'week_number' => $weekNumber,
-                    'from_league' => LeagueTypeEnum::Gold->value,
-                    'to_league'   => LeagueTypeEnum::Silver->value,
-                    'created_at'  => now(),
-                    'updated_at'  => now(),
-                ]);
-            }
-
-            foreach ($silverToBronze as $userId) {
-                LeagueWeeklyResult::insertOrIgnore([
-                    'user_id'     => $userId,
-                    'year'        => $year,
-                    'week_number' => $weekNumber,
-                    'from_league' => LeagueTypeEnum::Silver->value,
-                    'to_league'   => LeagueTypeEnum::Bronze->value,
-                    'created_at'  => now(),
-                    'updated_at'  => now(),
-                ]);
-            }
+    private function applyTransitions(
+        Collection $bronzeToSilver,
+        Collection $silverToGold,
+        Collection $goldToSilver,
+        Collection $silverToBronze,
+        int $year,
+        int $weekNumber
+    ): void {
+        DB::transaction(function () use (
+            $bronzeToSilver, $silverToGold, $goldToSilver, $silverToBronze, $year, $weekNumber
+        ) {
+            $this->recordResults($bronzeToSilver, LeagueTypeEnum::Bronze, LeagueTypeEnum::Silver, $year, $weekNumber);
+            $this->recordResults($silverToGold,   LeagueTypeEnum::Silver, LeagueTypeEnum::Gold,   $year, $weekNumber);
+            $this->recordResults($goldToSilver,   LeagueTypeEnum::Gold,   LeagueTypeEnum::Silver, $year, $weekNumber);
+            $this->recordResults($silverToBronze, LeagueTypeEnum::Silver, LeagueTypeEnum::Bronze, $year, $weekNumber);
 
             Liga::whereIn('user_id', $bronzeToSilver)->update(['league_id' => LeagueTypeEnum::Silver->value]);
             Liga::whereIn('user_id', $silverToGold)->update(['league_id' => LeagueTypeEnum::Gold->value]);
             Liga::whereIn('user_id', $goldToSilver)->update(['league_id' => LeagueTypeEnum::Silver->value]);
             Liga::whereIn('user_id', $silverToBronze)->update(['league_id' => LeagueTypeEnum::Bronze->value]);
         });
+    }
 
-        return self::SUCCESS;
+    private function recordResults(
+        Collection $userIds,
+        LeagueTypeEnum $fromLeague,
+        LeagueTypeEnum $toLeague,
+        int $year,
+        int $weekNumber
+    ): void {
+        foreach ($userIds as $userId) {
+            LeagueWeeklyResult::insertOrIgnore([
+                'user_id'     => $userId,
+                'year'        => $year,
+                'week_number' => $weekNumber,
+                'from_league' => $fromLeague->value,
+                'to_league'   => $toLeague->value,
+                'created_at'  => now(),
+                'updated_at'  => now(),
+            ]);
+        }
     }
 }

--- a/backend/src/tests/Feature/LigaTests/LigaPromotionLogicTest.php
+++ b/backend/src/tests/Feature/LigaTests/LigaPromotionLogicTest.php
@@ -53,4 +53,41 @@ class LigaPromotionLogicTest extends TestCase
         $this->assertEquals(LeagueTypeEnum::Gold,   Liga::where('user_id', $users[2]->id)->first()->league_id);
         $this->assertEquals(LeagueTypeEnum::Silver, Liga::where('user_id', $users[3]->id)->first()->league_id);
     }
+
+    public function test_bottom_3_in_gold_are_demoted_to_silver(): void
+    {
+        $users = User::factory(4)->create();
+        Liga::create(['user_id' => $users[0]->id, 'points_weekly' => 30, 'league_id' => LeagueTypeEnum::Gold]);
+        Liga::create(['user_id' => $users[1]->id, 'points_weekly' => 20, 'league_id' => LeagueTypeEnum::Gold]);
+        Liga::create(['user_id' => $users[2]->id, 'points_weekly' => 10, 'league_id' => LeagueTypeEnum::Gold]);
+        Liga::create(['user_id' => $users[3]->id, 'points_weekly' => 5,  'league_id' => LeagueTypeEnum::Gold]);
+
+        $this->artisan('liga:process-promotions')->assertExitCode(0);
+
+        $this->assertEquals(LeagueTypeEnum::Gold,   Liga::where('user_id', $users[0]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver,  Liga::where('user_id', $users[1]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver,  Liga::where('user_id', $users[2]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Silver,  Liga::where('user_id', $users[3]->id)->first()->league_id);
+    }
+
+    public function test_bottom_3_in_silver_are_demoted_to_bronze(): void
+    {
+        $users = User::factory(7)->create();
+        Liga::create(['user_id' => $users[0]->id, 'points_weekly' => 60, 'league_id' => LeagueTypeEnum::Silver]);
+        Liga::create(['user_id' => $users[1]->id, 'points_weekly' => 50, 'league_id' => LeagueTypeEnum::Silver]);
+        Liga::create(['user_id' => $users[2]->id, 'points_weekly' => 40, 'league_id' => LeagueTypeEnum::Silver]);
+        Liga::create(['user_id' => $users[3]->id, 'points_weekly' => 30, 'league_id' => LeagueTypeEnum::Silver]);
+        Liga::create(['user_id' => $users[4]->id, 'points_weekly' => 20, 'league_id' => LeagueTypeEnum::Silver]);
+        Liga::create(['user_id' => $users[5]->id, 'points_weekly' => 10, 'league_id' => LeagueTypeEnum::Silver]);
+        Liga::create(['user_id' => $users[6]->id, 'points_weekly' => 5,  'league_id' => LeagueTypeEnum::Silver]);
+
+        $this->artisan('liga:process-promotions')->assertExitCode(0);
+
+        $this->assertEquals(LeagueTypeEnum::Gold,   Liga::where('user_id', $users[0]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Gold,   Liga::where('user_id', $users[1]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Gold,   Liga::where('user_id', $users[2]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Bronze, Liga::where('user_id', $users[4]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Bronze, Liga::where('user_id', $users[5]->id)->first()->league_id);
+        $this->assertEquals(LeagueTypeEnum::Bronze, Liga::where('user_id', $users[6]->id)->first()->league_id);
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Implements the demotion logic in ProcessLeaguePromotions, completing the weekly league transition system (promotion + demotion).

## Changes

- Bottom 3 players in Gold are demoted to Silver (when Gold has >= 4 players)

- Bottom 3 players in Silver are demoted to Bronze (when Silver has >= 7 players)

- Players being promoted are excluded from demotion candidates to avoid conflicts

- Added tests for Gold to Silver and Silver to Bronze demotion scenarios

## Notes

The >= 7 threshold for Silver demotion ensures there are enough players so that the top 3 (promoted to Gold) and bottom 3 (demoted to Bronze) are always different people, with at least 1 player remaining in Silver.

## Refactor

Following reviewer feedback, the handle() method has been broken down into smaller, focused private methods:

- alreadyProcessed() — checks if the weekly transition has already run

- calculateTransitions() — computes which users are promoted/demoted

- applyTransitions() — runs the DB transaction with all the updates

- recordResults() — helper to avoid repetition when inserting LeagueWeeklyResult entries

## Testing

All tests passing