### PR TITLE
Sub-issue 1: add-complete-project-endpoint

### DIFF
--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -417,7 +417,7 @@ class ListProjectsController extends Controller
      *     ),
      *     @OA\Response(
      *         response=422,
-     *         description="Project is already completed or invalid URLs"
+     *         description="Project must be in 'in_progress' status to mark it as completed or invalid URLs"
      *     )
      * )
      */
@@ -441,7 +441,7 @@ class ListProjectsController extends Controller
         if ($project->status !== ProjectStatusEnum::IN_PROGRESS) {
             return response()->json([
                 'success' => false,
-                'message' => 'Project is already completed'
+                'message' => "Project must be in 'in_progress' status to mark it as completed"
             ], 422);
         }
         

--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -8,7 +8,9 @@ use App\Models\ListProjects;
 use App\Models\ContributorListProject;
 use Illuminate\Http\Request;
 use App\Enums\LanguageEnum;
+use App\Enums\ProjectStatusEnum;
 use App\Http\Requests\ListProjectRequest;
+use App\Http\Requests\CompleteProjectRequest;
 use App\Enums\ContributorStatusEnum;
 use App\Models\User;
 
@@ -63,7 +65,8 @@ class ListProjectsController extends Controller
      * )
      */
 
-    private function formatOwner(?User $user): ?array{
+    private function formatOwner(?User $user): ?array
+    {
 
         return $user ? ['id' => $user->id, 'name' => $user->name,] : null;
     }
@@ -360,6 +363,102 @@ class ListProjectsController extends Controller
         } catch (\Exception $e) {
             return response()->json([
                 'error' => 'Error updating project',
+                'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * @OA\Patch(
+     *     path="/api/codeconnect/{id}/complete",
+     *     summary="Mark a project as completed",
+     *     tags={"Codeconnect"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="github_url", type="string", nullable=true, example="https://github.com/user/project"),
+     *             @OA\Property(property="youtube_url", type="string", nullable=true, example="https://youtube.com/watch?v=...")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Project marked as completed successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Project marked as completed successfully"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="status", type="string", enum={"in_progress", "completed"}, example="completed"),
+     *                 @OA\Property(property="github_url", type="string", nullable=true, example="https://github.com/user/project"),
+     *                 @OA\Property(property="youtube_url", type="string", nullable=true, example="https://youtube.com/watch?v=...")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="User is not the owner of the project"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Project not found"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Project is already completed or invalid URLs"
+     *     )
+     * )
+     */
+    public function complete(CompleteProjectRequest $request, $id)
+    {
+        $project = ListProjects::find($id);
+        if (!$project) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Project not found'
+            ], 404);
+        }
+        
+        if ($project->user_id !== $request->user()->id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You are not the owner of this project'
+            ], 403);
+        }
+        
+        if ($project->status !== ProjectStatusEnum::IN_PROGRESS) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Project is already completed'
+            ], 422);
+        }
+        
+        try {
+            $project->update([
+                'status' => ProjectStatusEnum::COMPLETED,
+                'github_url' => $request->github_url ?? $project->github_url,
+                'youtube_url' => $request->youtube_url ?? $project->youtube_url,
+            ]);
+            return response()->json([
+                'success' => true,
+                'message' => 'Project marked as completed successfully',
+                'data' => $project->fresh()
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'error' => 'Error marking project as completed',
                 'message' => $e->getMessage()
             ], 500);
         }

--- a/backend/src/app/Http/Controllers/ListProjectsController.php
+++ b/backend/src/app/Http/Controllers/ListProjectsController.php
@@ -370,12 +370,12 @@ class ListProjectsController extends Controller
 
     /**
      * @OA\Patch(
-     *     path="/api/codeconnect/{id}/complete",
+     *     path="/api/codeconnect/{listProject}/complete",
      *     summary="Mark a project as completed",
      *     tags={"Codeconnect"},
      *     security={{"sanctum":{}}},
      *     @OA\Parameter(
-     *         name="id",
+     *         name="listProject",
      *         in="path",
      *         required=true,
      *         @OA\Schema(type="integer", example=1)
@@ -421,9 +421,9 @@ class ListProjectsController extends Controller
      *     )
      * )
      */
-    public function complete(CompleteProjectRequest $request, $id)
+    public function complete(CompleteProjectRequest $request, $listProjectId)
     {
-        $project = ListProjects::find($id);
+        $project = ListProjects::find($listProjectId);
         if (!$project) {
             return response()->json([
                 'success' => false,

--- a/backend/src/app/Http/Requests/CompleteProjectRequest.php
+++ b/backend/src/app/Http/Requests/CompleteProjectRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CompleteProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'github_url' => ['nullable', 'url'],
+            'youtube_url' => ['nullable', 'url'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'github_url.url' => 'The GitHub URL must be a valid URL.',
+            'youtube_url.url' => 'The YouTube URL must be a valid URL.',
+        ];
+    }
+}

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -81,7 +81,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::delete('/codeconnect/{listProject}/contributors/{contributor}', [ListProjectsController::class, 'removeContributor'])->name('contributors.destroy');
     Route::patch('/codeconnect/{listProject}/contributors/{contributor}/status', [ListProjectsController::class, 'updateContributorStatus'])->name('contributors.update-status');
     Route::post('/codeconnect/{listProject}/join', JoinProjectController::class)->name('codeconnect.join');
-    Route::patch('/codeconnect/{id}/complete', [ListProjectsController::class, 'complete'])->name('codeconnect.complete');
+    Route::patch('/codeconnect/{listProject}/complete', [ListProjectsController::class, 'complete'])->name('codeconnect.complete');
 });
 
 // ========== FORUM ENDPOINTS ==========

--- a/backend/src/routes/api.php
+++ b/backend/src/routes/api.php
@@ -81,6 +81,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::delete('/codeconnect/{listProject}/contributors/{contributor}', [ListProjectsController::class, 'removeContributor'])->name('contributors.destroy');
     Route::patch('/codeconnect/{listProject}/contributors/{contributor}/status', [ListProjectsController::class, 'updateContributorStatus'])->name('contributors.update-status');
     Route::post('/codeconnect/{listProject}/join', JoinProjectController::class)->name('codeconnect.join');
+    Route::patch('/codeconnect/{id}/complete', [ListProjectsController::class, 'complete'])->name('codeconnect.complete');
 });
 
 // ========== FORUM ENDPOINTS ==========

--- a/backend/src/tests/Feature/ListProjects/CompleteProjectTest.php
+++ b/backend/src/tests/Feature/ListProjects/CompleteProjectTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\ListProjects;
+
+use App\Enums\ProjectStatusEnum;
+use App\Models\ListProjects;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompleteProjectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_complete_project_successfully(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create([
+            'user_id' => $owner->id,
+            'status' => ProjectStatusEnum::IN_PROGRESS,
+        ]);
+
+        $response = $this->actingAs($owner)
+            ->patchJson("/api/codeconnect/{$project->id}/complete", [
+                'github_url' => 'https://github.com/user/project',
+                'youtube_url' => 'https://youtube.com/watch?v=123',
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('list_projects', [
+            'id' => $project->id,
+            'status' => ProjectStatusEnum::COMPLETED->value,
+            'github_url' => 'https://github.com/user/project',
+            'youtube_url' => 'https://youtube.com/watch?v=123',
+        ]);
+    }
+
+    public function test_unauthenticated_user_cannot_complete_project(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->patchJson("/api/codeconnect/{$project->id}/complete");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_non_owner_cannot_complete_project(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($otherUser)
+            ->patchJson("/api/codeconnect/{$project->id}/complete");
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'You are not the owner of this project']);
+    }
+
+    public function test_nonexistent_project_returns_404(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->patchJson('/api/codeconnect/99999/complete');
+
+        $response->assertStatus(404)
+            ->assertJson(['message' => 'Project not found']);
+    }
+
+    public function test_already_completed_project_returns_422(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create([
+            'user_id' => $owner->id,
+            'status' => ProjectStatusEnum::COMPLETED,
+        ]);
+
+        $response = $this->actingAs($owner)
+            ->patchJson("/api/codeconnect/{$project->id}/complete");
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => "Project must be in 'in_progress' status to mark it as completed"
+            ]);
+    }
+
+    public function test_invalid_url_returns_422(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($owner)
+            ->patchJson("/api/codeconnect/{$project->id}/complete", [
+                'github_url' => 'not-a-valid-url',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['github_url']);
+    }
+}

--- a/backend/src/tests/Feature/ListProjects/CompleteProjectTest.php
+++ b/backend/src/tests/Feature/ListProjects/CompleteProjectTest.php
@@ -39,29 +39,6 @@ class CompleteProjectTest extends TestCase
         ]);
     }
 
-    public function test_unauthenticated_user_cannot_complete_project(): void
-    {
-        $owner = User::factory()->create();
-        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
-
-        $response = $this->patchJson("/api/codeconnect/{$project->id}/complete");
-
-        $response->assertStatus(401);
-    }
-
-    public function test_non_owner_cannot_complete_project(): void
-    {
-        $owner = User::factory()->create();
-        $otherUser = User::factory()->create();
-        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
-
-        $response = $this->actingAs($otherUser)
-            ->patchJson("/api/codeconnect/{$project->id}/complete");
-
-        $response->assertStatus(403)
-            ->assertJson(['message' => 'You are not the owner of this project']);
-    }
-
     public function test_nonexistent_project_returns_404(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Context
Following Kenan's feedback on PR #870 about separating concerns, this sub-issue tracks the tests for business logic and validation flows in the complete project endpoint.

## Tests included
- 200 (happy path)
- 404 (project not found)
- 422 (already completed)
- 422 (invalid URL)