### PR TITLE
Sub-issue 2: complete-endpoint-authorization test

### DIFF
--- a/backend/src/tests/Feature/ListProjects/CompleteProjectTest.php
+++ b/backend/src/tests/Feature/ListProjects/CompleteProjectTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\ListProjects;
+
+use App\Enums\ProjectStatusEnum;
+use App\Models\ListProjects;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompleteProjectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unauthenticated_user_cannot_complete_project(): void
+    {
+        $owner = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->patchJson("/api/codeconnect/{$project->id}/complete");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_non_owner_cannot_complete_project(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $project = ListProjects::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($otherUser)
+            ->patchJson("/api/codeconnect/{$project->id}/complete");
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'You are not the owner of this project']);
+    }
+}


### PR DESCRIPTION
Adds tests covering authentication (401) and ownership (403) flows.

Reference: PR #870 review feedback about separating authorization from other endpoint concerns.

## Context
Following Kenan's feedback on PR #870 about separating concerns, 
this sub-issue tracks the tests for authorization flows in the 
complete project endpoint.

## What's included
- 401 (unauthenticated)
- 403 (non-owner)
