### PR TITLE
Add closeCodeConnectProject API function with types and tests

### DIFF
--- a/frontend/src/api/__tests__/endPointCodeConnect.test.ts
+++ b/frontend/src/api/__tests__/endPointCodeConnect.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IntCodeConnect } from "../../types";
 import {
   CodeConnectError,
+  closeCodeConnectProject,
   createCodeConnect,
   fetchCodeConnectAllProjects,
   fetchCodeConnectProject,
@@ -204,6 +205,55 @@ describe("fetchCodeConnectAllProjects", () => {
     mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
     await expect(fetchCodeConnectAllProjects()).rejects.toMatchObject({
+      message: "Error de connexió. Verifica la teva connexió a internet.",
+      code: "NETWORK_ERROR",
+    } as CodeConnectError);
+  });
+});
+
+describe("closeCodeConnectProject", () => {
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call the correct endpoint with PATCH method and token", async () => {
+    localStorage.setItem("auth_token", "test-token");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await closeCodeConnectProject(1, {
+      github_url: "https://github.com/user/project",
+      youtube_url: "https://youtube.com/watch?v=123",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/codeconnect/1/complete",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        }),
+        body: JSON.stringify({
+          github_url: "https://github.com/user/project",
+          youtube_url: "https://youtube.com/watch?v=123",
+        }),
+      }),
+    );
+  });
+
+  it("should throw an error on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    await expect(closeCodeConnectProject(1, {})).rejects.toMatchObject({
       message: "Error de connexió. Verifica la teva connexió a internet.",
       code: "NETWORK_ERROR",
     } as CodeConnectError);

--- a/frontend/src/api/endPointCodeConnect.ts
+++ b/frontend/src/api/endPointCodeConnect.ts
@@ -174,3 +174,57 @@ export const fetchCodeConnectAllProjects = async (
     throw error;
   }
 };
+
+export const closeCodeConnectProject = async (
+  projectId: number,
+  data: { github_url?: string; youtube_url?: string },
+): Promise<ApiProjectResponse> => {
+  const url = `${API_URL}${END_POINTS.codeconnect.get}/${projectId}/complete`;
+  const token = localStorage.getItem("auth_token");
+
+  try {
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Error ${response.status}: ${response.statusText}`;
+      let errorCode: string | undefined;
+
+      try {
+        const errorData = (await response.json()) as {
+          message?: string;
+          code?: string;
+        };
+
+        errorMessage = errorData.message || errorMessage;
+        errorCode = errorData.code;
+      } catch {
+        // Ignore the parsing error and use the default values that have already been set.
+      }
+
+      throw {
+        message: errorMessage,
+        status: response.status,
+        code: errorCode,
+      } as CodeConnectError;
+    }
+
+    return (await response.json()) as ApiProjectResponse;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw {
+        message: "Error de connexió. Verifica la teva connexió a internet.",
+        code: "NETWORK_ERROR",
+      } as CodeConnectError;
+    }
+
+    throw error;
+  }
+};

--- a/frontend/src/types/codeConnectTypes.ts
+++ b/frontend/src/types/codeConnectTypes.ts
@@ -45,6 +45,9 @@ export interface ApiProjectData {
   roadmap?: { task: string; done: boolean }[];
   time_duration: string;
   title: string;
+  project_status?: "in_progress" | "completed";
+  github_url?: string | null;
+  youtube_url?: string | null;
 }
 
 export interface ApiContributor {


### PR DESCRIPTION
### **Context**
A separate branch was created from the original (feature/820-Modal-complete-project-form-2_2) because it had become too large.
In this first part, we have reduced it to "just 107" lines, including 50 lines of tests.

### **Description**

This PR adds the API layer needed to connect the frontend with the mark-as-completed endpoint.

### **What's included?**

New closeCodeConnectProject function in endPointCodeConnect.ts that makes a PATCH /api/codeconnect/{id}/complete call with token authentication
New optional fields in ApiProjectData type: project_status, github_url and youtube_url, which the backend exposes after merging PR #819
Tests for closeCodeConnectProject: verifies it calls the correct endpoint with PATCH method and token, and throws an error on network failure

**### Dependencies**
This PR requires PR #819 (backend) to be merged first so the endpoint exists.